### PR TITLE
��� URGENT: Add logs/.gitkeep to fix Django logging errors

### DIFF
--- a/backend/logs/.gitkeep
+++ b/backend/logs/.gitkeep
@@ -1,0 +1,1 @@
+# Django log directory


### PR DESCRIPTION
## ��� **紧急修复：添加logs/.gitkeep修复Django日志错误**

### ❌ **核心问题**
用户正确指出我们的修复不完整！尽管PR #11修复了一些问题，dev分支的Post-Merge Validation仍在失败：

**错误**: `FileNotFoundError: /home/runner/work/Bravo/Bravo/backend/logs/bravo.log`

### ��� **根本原因**  
`backend/logs/` 目录被 `.gitignore` 忽略了：
```
# .gitignore line 82:
logs/
```

这导致CI环境中缺少该目录，Django日志配置失败。

### ���️ **修复方案**
添加 `backend/logs/.gitkeep` 文件：
- 使用 `git add -f` 强制添加，绕过 `.gitignore`
- 确保CI环境中存在logs目录
- 解决Django日志handler配置错误

### ✅ **预期效果**
合并后的dev分支应该：
- ✅ Django服务器正常启动
- ✅ Integration Smoke Test通过
- ✅ Post-Merge Validation完全通过

### ⚡ **紧急性**
这是修复dev分支CI/CD流程的最后一步，必须立即处理。

对之前过早宣布成功的错误深表歉意，这次会确保真正解决问题。