### PR TITLE
fix(ci): 修复dev分支所有工作流失败的核心问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clean:e2e": "cd e2e && rm -rf node_modules playwright-report test-results lighthouse-report",
     "install:all": "npm install && cd frontend && npm install && cd ../e2e && npm install",
     "postinstall:disabled": "npm run e2e:install",
-    "prepare": "is-ci || husky install",
+    "prepare": "node -e \"if (process.env.CI) process.exit(0); try { require('child_process').execSync('npx husky install', {stdio: 'inherit'}); } catch (e) { console.log('Husky install skipped'); }\"",
     "check:syntax": "node scripts/check-syntax.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## ��� 根本问题分析

按照用户要求，等待dev分支所有工作流完成后分析，发现7个工作流全部失败，根本原因相同：

### ��� 具体错误
```bash
> is-ci || husky install
sh: 1: is-ci: not found  
sh: 1: husky: not found
npm error code 127
```

### �� 影响的工作流
- Feature-Test Coverage Map
- Post-Merge Smoke Tests  
- Dependency Conflict Check
- 其他4个使用npm install的工作流

### ���️ 解决方案
修改package.json prepare脚本：
- **CI环境**：检测`process.env.CI`，直接退出
- **本地环境**：使用`npx husky install`，错误时优雅降级

### ✅ 验证
- `CI=true npm run prepare` ✅ (直接退出)
- `npm run prepare` ✅ (本地正常)

**严格按照项目规范，完整pre-commit流程，一次性解决核心问题！**