### PR TITLE
fix(test): 第四轮修复 - Element Plus组件测试渲染问题

### DIFF
--- a/frontend/src/views/Login.spec.ts
+++ b/frontend/src/views/Login.spec.ts
@@ -28,12 +28,12 @@ describe('Login.vue', () => {
     wrapper = mount(Login, {
       global: {
         stubs: {
-          ElCard: { template: '<div class="el-card"><slot /></div>' },
-          ElForm: { template: '<form class="el-form"><slot /></form>' },
-          ElFormItem: {
+          'el-card': { template: '<div class="el-card"><slot /></div>' },
+          'el-form': { template: '<form class="el-form"><slot /></form>' },
+          'el-form-item': {
             template: '<div class="el-form-item"><slot /></div>',
           },
-          ElInput: {
+          'el-input': {
             template:
               '<input class="el-input" v-bind="$attrs" @input="handleInput" />',
             props: ['type', 'placeholder', 'modelValue'],
@@ -45,7 +45,7 @@ describe('Login.vue', () => {
               },
             },
           },
-          ElButton: {
+          'el-button': {
             template:
               '<button class="el-button" @click="handleClick"><slot /></button>',
             emits: ['click'],


### PR DESCRIPTION
## ��� 第四轮迭代修复

基于前三轮成功修复的基础上：
- ✅ 第1轮：npm prepare脚本问题  
- ✅ 第2轮：安全漏洞问题
- ✅ 第3轮：依赖冲突检查问题

现在修复最后的前端测试问题。

## ��� 问题分析

**具体失败：**


**根本原因：**
- Login.vue组件使用**kebab-case**：、、
- 测试stubs使用**PascalCase**：、、
- 命名不匹配导致stubs无法正确映射组件

## ��� 修复方案

统一所有Element Plus stubs使用kebab-case命名：


## ✅ 预期修复的检查
- Quick Frontend Test (Login组件渲染测试)  
- Post-Merge Smoke Tests (前端单元测试)

**继续迭代策略，逐步完善CI通过率！**