### PR TITLE
fix(deps): 第5轮修复 - Django调试工具依赖问题

### DIFF
--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -29,6 +29,8 @@ safety>=3.0.0
 
 # 开发调试工具
 django-debug-toolbar==4.2.0
+django-extensions==3.2.3
+django-silk==5.0.4
 
 # 代码质量
 pylint==3.0.3


### PR DESCRIPTION
## ��� 第5轮最终修复

基于前4轮的巨大成功：
- ✅ 第1轮：npm prepare脚本
- ✅ 第2轮：安全漏洞  
- ✅ 第3轮：依赖冲突
- ✅ 第4轮：Element Plus测试

现在修复最后1个具体问题！

## ��� 问题定位

**Integration Smoke Test失败：**
```
ModuleNotFoundError: No module named 'django_extensions'
curl: Failed to connect to localhost port 8000
```

**根本原因：**
- Django `local.py` 在 `DEBUG=True` 时自动添加调试工具到 `INSTALLED_APPS`
- CI环境使用 `test.txt` requirements但缺少这些依赖
- Django服务器启动失败，导致健康检查无法连接

## ��� 修复方案

在 `backend/requirements/test.txt` 中添加：
```
django-extensions==3.2.3
django-silk==5.0.4
```

## ✅ 预期效果
- Integration Smoke Test 通过
- Django服务器成功启动  
- 健康检查 `/health/` 正常响应

**这将是最终的完美修复！���**