### PR TITLE
fix(ci): 修复dev分支TypeScript类型检查失败

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -71,7 +71,8 @@ export default [
             // - COVERAGE_THRESHOLDS：测试覆盖率配置常量
             // - router-link/router-view：Vue Router组件名
             // - ./开头：文件路径配置（如Jest配置中的路径映射）
-            regex: '^(@|COVERAGE_THRESHOLDS|router-link|router-view|\\./)',
+            // - el-开头：Element Plus组件名（用于测试stub配置）
+            regex: '^(@|COVERAGE_THRESHOLDS|router-link|router-view|\\./|el-)',
             match: false,
           },
         },
@@ -117,6 +118,7 @@ export default [
     rules: {
       'no-console': 'off', // 测试文件中允许console
       '@typescript-eslint/no-explicit-any': 'off', // 测试文件中允许any类型
+      '@typescript-eslint/naming-convention': 'off', // 测试文件中关闭命名规范检查，允许Vue组件的kebab-case名称
     },
   },
   // 配置文件特定规则

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^0.34.6",
     "@vitest/ui": "^0.34.6",
+    "@vue/shared": "^3.5.21",
     "@vue/test-utils": "^2.4.2",
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^10.1.8",

--- a/frontend/src/views/Blog.vue
+++ b/frontend/src/views/Blog.vue
@@ -13,12 +13,12 @@
         :key="post.id"
         class="blog-item"
         data-testid="blog-item"
-        @click="goToBlogDetail(post.id)"
-        @keydown.enter="goToBlogDetail(post.id)"
-        @keydown.space="goToBlogDetail(post.id)"
         role="button"
         tabindex="0"
         :aria-label="`查看博客：${post.title}`"
+        @click="goToBlogDetail(post.id)"
+        @keydown.enter="goToBlogDetail(post.id)"
+        @keydown.space="goToBlogDetail(post.id)"
       >
         <h3>{{ post.title }}</h3>
         <p>{{ post.content }}</p>
@@ -28,16 +28,16 @@
     <!-- 搜索功能 -->
     <nav class="search-section" role="search">
       <input
+        v-model="searchKeyword"
         type="text"
         placeholder="搜索博客..."
         data-testid="search-input"
-        v-model="searchKeyword"
         aria-label="搜索博客"
       />
       <button
         data-testid="search-button"
-        @click="searchBlog"
         aria-label="执行搜索"
+        @click="searchBlog"
       >
         搜索
       </button>
@@ -46,8 +46,8 @@
     <!-- 分类筛选 -->
     <div class="filter-section">
       <select
-        data-testid="category-filter"
         v-model="selectedCategory"
+        data-testid="category-filter"
         @change="filterByCategory"
       >
         <option value="">所有分类</option>
@@ -60,8 +60,8 @@
     <!-- 创建博客按钮 -->
     <button
       data-testid="create-post"
-      @click="createPost"
       class="create-button"
+      @click="createPost"
     >
       创建新博客
     </button>
@@ -69,20 +69,20 @@
     <!-- 博客编辑表单（隐藏状态，用于测试） -->
     <div v-if="showEditForm" class="edit-form" data-testid="edit-form">
       <input
+        v-model="editForm.title"
         type="text"
         placeholder="博客标题"
         data-testid="post-title"
-        v-model="editForm.title"
       />
       <textarea
+        v-model="editForm.content"
         placeholder="博客内容"
         data-testid="post-content"
-        v-model="editForm.content"
       ></textarea>
       <button
         data-testid="publish-button"
-        @click="publishPost"
         class="publish-button"
+        @click="publishPost"
       >
         发布
       </button>
@@ -92,15 +92,15 @@
     <div v-if="showActions" class="blog-actions" data-testid="blog-actions">
       <button
         data-testid="edit-button"
-        @click="editPost"
         class="edit-button"
+        @click="editPost"
       >
         编辑
       </button>
       <button
         data-testid="delete-button"
-        @click="deletePost"
         class="delete-button"
+        @click="deletePost"
       >
         删除
       </button>
@@ -109,8 +109,8 @@
     <!-- 加载更多按钮 -->
     <button
       data-testid="load-more"
-      @click="loadMore"
       class="load-more-button"
+      @click="loadMore"
     >
       加载更多
     </button>

--- a/frontend/src/views/BlogDetail.vue
+++ b/frontend/src/views/BlogDetail.vue
@@ -21,17 +21,17 @@
         <div class="post-actions" data-testid="blog-actions">
           <button
             data-testid="edit-button"
-            @click="editPost"
             class="edit-button"
             aria-label="编辑博客"
+            @click="editPost"
           >
             编辑
           </button>
           <button
             data-testid="delete-button"
-            @click="deletePost"
             class="delete-button"
             aria-label="删除博客"
+            @click="deletePost"
           >
             删除
           </button>
@@ -42,23 +42,23 @@
     <!-- 编辑表单（隐藏状态，用于测试） -->
     <div v-if="showEditForm" class="edit-form" data-testid="edit-form">
       <input
+        v-model="editForm.title"
         type="text"
         placeholder="博客标题"
         data-testid="post-title"
-        v-model="editForm.title"
         aria-label="博客标题"
       />
       <textarea
+        v-model="editForm.content"
         placeholder="博客内容"
         data-testid="post-content"
-        v-model="editForm.content"
         aria-label="博客内容"
       ></textarea>
       <button
         data-testid="publish-button"
-        @click="publishPost"
         class="publish-button"
         aria-label="发布博客"
+        @click="publishPost"
       >
         发布
       </button>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -21,8 +21,8 @@
         <el-form-item>
           <el-button
             type="primary"
-            @click="handleLogin"
             data-testid="login-button"
+            @click="handleLogin"
           >
             登录
           </el-button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,7 @@
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitest/coverage-v8": "^0.34.6",
         "@vitest/ui": "^0.34.6",
+        "@vue/shared": "^3.5.21",
         "@vue/test-utils": "^2.4.2",
         "eslint": "^8.53.0",
         "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## 问题描述
dev分支CI失败，原因是TypeScript类型检查无法通过。

## 根本原因
Vue.js @vue/shared模块的dist目录缺失，导致vue-tsc命令执行失败：
```
Error: Cannot find module './dist/shared.cjs.js'
```

## 解决方案
1. **重新安装npm依赖** - 修复Vue共享模块缺失的dist目录
2. **更新ESLint配置** - 在测试文件中禁用命名规范检查，允许Vue组件的kebab-case命名（如el-card, el-form等）

## 验证结果
- ✅ TypeScript类型检查通过: `npm run type-check`
- ✅ ESLint检查通过: `npm run lint`
- ✅ 所有pre-commit检查通过

## 影响范围
- 前端TypeScript配置
- ESLint配置（仅影响测试文件）
- 不破坏任何现有功能

## 测试
- 本地TypeScript类型检查通过
- ESLint命名规范检查正确处理Vue组件名