### PR TITLE
fix(ci): 修复Feature Coverage工作流文件路径问题

### DIFF
--- a/.github/workflows/feature-map.yml
+++ b/.github/workflows/feature-map.yml
@@ -107,7 +107,7 @@ jobs:
 
           # 读取覆盖率数据
           FEATURE_COVERAGE=$(node -e "
-            const report = JSON.parse(require('fs').readFileSync('feature-test-map.json', 'utf8'));
+            const report = JSON.parse(require('fs').readFileSync('docs/02_test_report/feature-test-map.json', 'utf8'));
             console.log(Math.round(report.summary.coveragePercentage));
           ")
 
@@ -145,7 +145,7 @@ jobs:
           EOF
 
           node -e "
-            const report = JSON.parse(require('fs').readFileSync('feature-test-map.json', 'utf8'));
+            const report = JSON.parse(require('fs').readFileSync('docs/02_test_report/feature-test-map.json', 'utf8'));
             console.log('- Total Features:', report.summary.totalFeatures);
             console.log('- Covered Features:', report.summary.coveredFeatures);
             console.log('- Uncovered Features:', report.summary.totalFeatures - report.summary.coveredFeatures);
@@ -170,10 +170,10 @@ jobs:
         with:
           name: feature-coverage-reports
           path: |
-            feature-test-map.md
-            feature-test-map.json
-            feature-test-mapping.json
-            feature-coverage-report.json
+            docs/02_test_report/feature-test-map.md
+            docs/02_test_report/feature-test-map.json
+            docs/02_test_report/feature-test-mapping.json
+            docs/02_test_report/feature-coverage-report.json
             frontend/coverage/
             backend/htmlcov/
           retention-days: 30
@@ -186,7 +186,7 @@ jobs:
             const fs = require('fs');
 
             try {
-              const report = JSON.parse(fs.readFileSync('feature-test-map.json', 'utf8'));
+              const report = JSON.parse(fs.readFileSync('docs/02_test_report/feature-test-map.json', 'utf8'));
               const coverage = Math.round(report.summary.coveragePercentage);
 
               let emoji = '🔴';


### PR DESCRIPTION
## ��� 修复问题

**Feature Coverage工作流失败**，错误信息：
```
Error: ENOENT: no such file or directory, open 'feature-test-map.json'
```

## ��� 根本原因

工作流期望在根目录找到 `feature-test-map.json`，但 `buildFeatureMap.js` 脚本将文件生成到 `docs/02_test_report/` 目录。

## ✅ 解决方案

更新所有文件路径引用到正确的 `docs/02_test_report/` 路径：

1. **Generate coverage badges步骤** - 修复JSON文件读取路径
2. **Create coverage summary步骤** - 修复报告数据读取路径  
3. **Comment PR with coverage步骤** - 修复PR评论数据路径
4. **Upload coverage reports步骤** - 修复artifact上传路径

## ��� 测试验证

- ✅ Workflow语法检查通过
- ✅ Pre-commit检查通过
- ✅ 路径修复符合buildFeatureMap.js脚本的实际输出

## ��� 影响范围

仅影响Feature-Test Coverage Map工作流，不影响其他CI流程。

## ��� 预期结果

Feature Coverage工作流现在应该能找到正确的JSON文件，不再出现文件不存在错误。