### PR TITLE
fix(deps): 添加缺失的flake8依赖到test.txt

### DIFF
--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -37,6 +37,7 @@ pylint==3.0.3
 black>=22.0.0,<24.0.0
 isort==5.12.0
 mypy==1.7.1
+flake8==6.0.0
 
 # 数据库配置
 dj-database-url==2.1.0


### PR DESCRIPTION
## ��� 修复问题

**Dev Branch Optimized Post-Merge工作流失败**，具体错误：

```
/opt/hostedtoolcache/Python/3.11.13/x64/bin/python: No module named flake8
##[error]Process completed with exit code 1.
```

## ��� 根本原因

CI工作流在 `fast-validation.yml` 中使用flake8进行后端lint检查：

```yaml
"lint-backend")
  cd backend && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
```

但是 `backend/requirements/test.txt` 中没有包含flake8依赖，导致模块找不到。

## ✅ 解决方案

在 `backend/requirements/test.txt` 的代码质量工具部分添加：

```diff
# 代码质量
pylint==3.0.3
black>=22.0.0,<24.0.0
isort==5.12.0
mypy==1.7.1
+ flake8==6.0.0
```

## ��� 测试验证

- ✅ Pre-commit检查全部通过，包括flake8检查
- ✅ 依赖版本与现有工具兼容
- ✅ 修复后CI应能正常执行后端lint检查

## ��� 影响范围

仅影响测试环境依赖，修复后端lint检查失败问题。不影响生产环境。

## ��� 预期结果

修复后，Dev Branch Optimized Post-Merge工作流的后端lint检查步骤应该能够成功运行。