### PR TITLE
fix(ci): 修复后端lint检查中虚拟环境激活问题

### DIFF
--- a/.github/workflows/fast-validation.yml
+++ b/.github/workflows/fast-validation.yml
@@ -46,7 +46,7 @@ jobs:
             cd frontend && npm run lint
               ;;
           "lint-backend")
-            cd backend && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
+            cd backend && source .venv/bin/activate && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
               ;;
             "type-check")
               cd frontend && npm run type-check


### PR DESCRIPTION
## ��� 修复问题

**Dev Branch Optimized Post-Merge工作流**中的lint-backend步骤失败：

```
/opt/hostedtoolcache/Python/3.11.13/x64/bin/python: No module named flake8
##[error]Process completed with exit code 1.
```

## ��� 根本原因分析

1. **依赖安装正确**：日志显示flake8-6.0.0已成功安装到虚拟环境
2. **虚拟环境未激活**：setup-cached-env action将后端依赖安装到 `backend/.venv` 中
3. **运行环境错误**：lint-backend步骤直接运行 `python -m flake8`，未激活虚拟环境

## ��� 技术细节

**现有问题代码**：
```yaml
"lint-backend")
  cd backend && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
```

**修复后代码**：
```yaml
"lint-backend")
  cd backend && source .venv/bin/activate && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
```

## ✅ 解决方案

在 `.github/workflows/fast-validation.yml` 的lint-backend步骤中：
- 添加 `source .venv/bin/activate` 激活虚拟环境
- 确保flake8命令在正确的Python环境中运行

## ��� 验证方法

- ✅ Pre-commit检查全部通过
- ✅ GitHub Actions workflow语法检查通过
- ✅ 修复后CI应能找到并运行flake8

## ��� 影响范围

仅影响CI工作流中的后端lint检查步骤，不影响其他功能。

## ��� 预期结果

修复后，Dev Branch Optimized Post-Merge工作流的后端lint检查应该能够：
1. 正确激活虚拟环境
2. 找到并运行flake8模块
3. 完成代码质量检查