### PR TITLE
fix(ci): flake8排除虚拟环境目录避免检查第三方库

### DIFF
--- a/.github/workflows/fast-validation.yml
+++ b/.github/workflows/fast-validation.yml
@@ -46,7 +46,7 @@ jobs:
             cd frontend && npm run lint
               ;;
           "lint-backend")
-            cd backend && source .venv/bin/activate && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
+            cd backend && source .venv/bin/activate && python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__,.venv
               ;;
             "type-check")
               cd frontend && npm run type-check


### PR DESCRIPTION
## ��� 修复问题

**Dev Branch Optimized Post-Merge工作流**中的lint-backend步骤失败，出现大量F821错误：

```
./.venv/lib/python3.11/site-packages/blib2to3/pgen2/tokenize.py:465:62: F821 undefined name 'strstart'
./.venv/lib/python3.11/site-packages/cffi/verifier.py:25:30: F821 undefined name 'unicode'
./.venv/lib/python3.11/site-packages/gevent/_abstract_linkable.py:174:16: F821 undefined name 'getcurrent'
... 数百个类似错误
```

## ��� 根本原因分析

1. **虚拟环境激活成功**：`source .venv/bin/activate` 正常工作
2. **flake8配置问题**：当前exclude只包含 `migrations,__pycache__`
3. **检查范围过大**：flake8检查了整个当前目录，包括 `.venv` 虚拟环境
4. **第三方库问题**：第三方库使用条件导入和动态定义，导致F821错误

## �� 技术细节

**问题命令**：
```bash
python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__
```

**修复后命令**：
```bash
python -m flake8 . --select=E9,F63,F7,F82 --exclude=migrations,__pycache__,.venv
```

## ✅ 解决方案

在 `.github/workflows/fast-validation.yml` 中的flake8命令添加 `.venv` 到exclude列表：
- 确保只检查项目源代码
- 跳过虚拟环境中的第三方库
- 避免第三方库导致的误报

## ��� 验证方法

- ✅ Pre-commit检查全部通过，包括本地flake8检查
- ✅ GitHub Actions workflow语法检查通过
- ✅ 修复后应该消除所有第三方库F821错误

## ��� 影响范围

仅影响CI工作流中的后端lint检查配置，不影响项目代码质量检查的有效性。

## ��� 预期结果

修复后，Dev Branch Optimized Post-Merge工作流的后端lint检查应该：
1. 只检查项目代码（不检查.venv目录）
2. 消除第三方库导致的F821误报
3. 成功完成lint检查步骤