### PR TITLE
fix(ci): 修复npm缓存路径导致的Dependency Check失败

### DIFF
--- a/.github/workflows/on-merge-dev.yml
+++ b/.github/workflows/on-merge-dev.yml
@@ -187,12 +187,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+      - name: Setup Cached Environment
+        uses: ./.github/actions/setup-cached-env
 
       - name: Check NPM Dependencies
         working-directory: ./frontend
@@ -201,11 +197,6 @@ jobs:
           # 检查依赖漏洞 (临时降低审计级别，跳过开发依赖的安全问题)
           npm audit --audit-level=critical --production || echo "⚠️ 发现安全问题，但仅影响开发环境"
           echo "✅ NPM依赖检查完成"
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
 
       - name: Check Python Dependencies
         working-directory: ./backend


### PR DESCRIPTION
## 修复npm缓存路径问题

### 问题
Dependency Conflict Check失败，错误：Some specified paths were not resolved, unable to cache dependencies

### 原因
on-merge-dev.yml中使用了错误的cache-dependency-path: frontend/package-lock.json

### 修复
- 移除错误的cache-dependency-path配置
- 统一使用setup-cached-env action
- 简化冗余的Python环境设置

### 影响
修复Dev Branch - Post-Merge Validation工作流的Dependency Conflict Check步骤失败问题

紧急修复，需要立即合并。