### PR TITLE
fix: Add MySQL connection verification to regression and E2E test workflows

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -85,6 +85,13 @@ jobs:
 
       - name: Setup test database
         run: |
+          echo "Verifying MySQL connection..."
+          until mysqladmin ping -h 127.0.0.1 -P 3306 -u root -proot_password --silent; do
+            echo "Waiting for MySQL to be ready..."
+            sleep 2
+          done
+          echo "MySQL is ready!"
+
           mysql -h 127.0.0.1 -P 3306 -u root -proot_password -e "
             CREATE DATABASE IF NOT EXISTS bravo_test;
             GRANT ALL PRIVILEGES ON bravo_test.* TO 'bravo_user'@'%';

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -150,6 +150,14 @@ jobs:
         run: |
           echo "Running API compatibility tests..."
 
+          # 确保MySQL服务已准备就绪
+          echo "Verifying MySQL connection..."
+          until mysqladmin ping -h 127.0.0.1 -P 3306 -u root -proot_password --silent; do
+            echo "Waiting for MySQL to be ready..."
+            sleep 2
+          done
+          echo "MySQL is ready!"
+
           # 启动后端服务器
           cd backend
           source .venv/bin/activate


### PR DESCRIPTION
## 修复内容

- 在回归测试工作流中添加MySQL连接验证
- 在E2E测试工作流中添加MySQL连接验证
- 确保数据库服务准备就绪后再尝试连接
- 修复CI中的'Unknown database bravo_test'错误

## 测试

- [x] 修复了回归测试工作流
- [x] 修复了E2E测试工作流
- [x] 验证了所有测试工作流的数据库配置一致性

## 影响范围

- GitHub Actions工作流
- CI/CD流程稳定性