### PR TITLE
fix: upgrade Node.js from 18 to 20 to resolve Vite compatibility issues

### DIFF
--- a/e2e/Dockerfile.test
+++ b/e2e/Dockerfile.test
@@ -1,5 +1,5 @@
 # E2E测试环境 Dockerfile
-FROM node:18-slim
+FROM node:20-slim
 
 # 设置工作目录
 WORKDIR /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Vue 前端 Dockerfile 模板
 
 # 构建阶段
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,5 +1,5 @@
 # 开发环境 Dockerfile - 修复版
-FROM node:18-alpine
+FROM node:20-alpine
 
 # 设置工作目录
 WORKDIR /app

--- a/frontend/Dockerfile.test
+++ b/frontend/Dockerfile.test
@@ -1,6 +1,6 @@
 # Vue 前端测试环境 Dockerfile
 
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## ��� 修复说明

### 问题描述
- Vite v7.1.5 需要 Node.js 20.19+ 版本
- 之前使用 Node.js 18 导致前端构建失败
- 错误：`[vite:vue] crypto.hash is not a function`

### 修复内容
- ✅ **frontend/Dockerfile.test**: `node:18-alpine` → `node:20-alpine`
- ✅ **frontend/Dockerfile**: `node:18-alpine` → `node:20-alpine`  
- ✅ **frontend/Dockerfile.dev**: `node:18-alpine` → `node:20-alpine`
- ✅ **e2e/Dockerfile.test**: `node:18-slim` → `node:20-slim`

### 验证结果
- ✅ 所有 Docker 构建成功
- ✅ 前端测试通过 (31s)
- ✅ 后端测试通过 (2m39s)
- ✅ 质量检查通过 (6s)

### 影响评估
- **正面影响**: 修复CI/CD管道中的构建失败问题
- **风险评估**: 低风险，Node.js 20是LTS版本，向后兼容
- **测试覆盖**: 所有测试套件已验证通过

## ��� 遵循正确流程
- ✅ **feature → dev**: 这个PR (正确)
- ��� **dev → main**: 下一步通过单独PR

## ��� 工作流验证
已通过完整的 Feature Branch 验证流程：
- Quick Environment Setup ✅
- Quick Backend Tests ✅  
- Quick Frontend Tests ✅
- Quick Quality Check ✅
- Development Feedback ✅

## ��� 下一步
合并到dev分支后，此修复将解决post-merge工作流中的失败问题，提升CI/CD稳定性。