### PR TITLE
fix(e2e): 修复E2E容器python软链和MySQL数据库检查

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,10 +13,16 @@ services:
       - /var/lib/mysql # 使用内存存储，加速测试
     command: --default-authentication-plugin=mysql_native_password --skip-log-bin
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "mysqladmin ping -h localhost && mysql -u root -proot_password -e 'USE bravo_test; SELECT 1;'",
+        ]
       interval: 5s
-      timeout: 3s
-      retries: 10
+      timeout: 5s
+      retries: 15
 
   # 后端测试服务
   backend-test:

--- a/e2e/Dockerfile.test
+++ b/e2e/Dockerfile.test
@@ -4,8 +4,10 @@ FROM node:20-slim
 # 设置工作目录
 WORKDIR /app
 
-# 安装系统依赖（Playwright需要）
+# 安装系统依赖（Playwright需要）+ Python
 RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
     wget \
     ca-certificates \
     fonts-liberation \
@@ -43,6 +45,7 @@ RUN apt-get update && apt-get install -y \
     lsb-release \
     xdg-utils \
     curl \
+    && ln -s /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
 # 复制package文件


### PR DESCRIPTION
��� **解决根本问题**

基于深入失败日志分析，修复两个关键根本原因：

## ❌ **原问题**
1.  - E2E容器只有python3，缺少python软链
2.  - MySQL健康检查只检查服务，不检查数据库创建

## ��� **精准修复**

### 1. **E2E容器Python软链**


### 2. **MySQL数据库创建检查**


## ��� **预期效果**
- ✅ 解决  
- ✅ 解决 
- ✅ E2E测试容器正常运行
- ✅ 数据库依赖的工作流正常执行

## ��� **修复验证**
根据实际失败日志的深层原因分析，直接针对性解决核心问题。