### PR TITLE
fix(e2e): 修复npm install audit错误导致@playwright/test缺失

### DIFF
--- a/e2e/Dockerfile.test
+++ b/e2e/Dockerfile.test
@@ -64,8 +64,8 @@ RUN npx playwright install --with-deps
 # 复制测试代码
 COPY . .
 
-# 重新安装依赖确保所有文件同步
-RUN npm install --verbose
+# 重新安装依赖确保所有文件同步（跳过audit避免404错误）
+RUN npm install --verbose --no-audit
 
 # 设置环境变量
 ENV CI=true


### PR DESCRIPTION
## ��� 修复内容

### E2E容器依赖安装问题
- **问题**: 第二次npm install遇到audit 404错误中断安装
- **原因**: npm audit请求npmmirror返回404导致安装流程中断  
- **修复**: 添加--no-audit标志跳过audit检查

### 修改文件
- `e2e/Dockerfile.test`: 添加--no-audit标志

### 预期效果
- ✅ E2E容器能正确安装@playwright/test
- ✅ Fast Validation Pipeline能通过
- ��� 仍需解决MySQL时序问题(后续PR)