### PR TITLE
fix(e2e): 修复E2E容器包名冲突根本问题 - playwright vs @playwright/test

### DIFF
--- a/e2e/Dockerfile.test
+++ b/e2e/Dockerfile.test
@@ -71,9 +71,9 @@ RUN npm install --verbose --no-audit
 ENV CI=true
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
-# 健康检查
+# 健康检查 - 使用npm script验证安装
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD npx playwright --version || exit 1
+    CMD npm list @playwright/test > /dev/null 2>&1 || exit 1
 
-# 默认命令
-CMD ["npx", "playwright", "test", "--config=playwright.config.ts"]
+# 默认命令 - 使用npm script确保正确的@playwright/test包
+CMD ["npm", "run", "test"]


### PR DESCRIPTION
## ��� 根本问题发现与修复

### ��� 真正的问题根源
**不是依赖安装问题，是包名冲突问题！**

#### ❌ 之前的错误分析
- 错误认为是依赖没安装
- 反复修复npm install逻辑
- 都是无用功！

#### ✅ 真正的根本原因
- **本地安装**: `@playwright/test@^1.40.0` ✅
- **执行命令**: `npx playwright test` ❌
- **包名冲突**: `playwright` ≠ `@playwright/test` 

### ��� 修复内容

#### CMD命令修复
```dockerfile
# ❌ 之前 - 错误的包名
CMD ["npx", "playwright", "test", "--config=playwright.config.ts"]

# ✅ 现在 - 正确使用npm script
CMD ["npm", "run", "test"]
```

#### 健康检查修复
```dockerfile
# ❌ 之前 - 可能的包冲突
CMD npx playwright --version || exit 1

# ✅ 现在 - 直接验证依赖安装
CMD npm list @playwright/test > /dev/null 2>&1 || exit 1
```

### ��� 技术分析

#### 错误序列
1. `npx playwright test` 尝试使用 `playwright` 包
2. `npm warn exec: playwright@1.55.0 will be installed`
3. `Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@playwright/test'`

#### 根本原因
- `playwright` 和 `@playwright/test` 是**不同的包**
- npx尝试安装错误的包版本
- 导致模块解析失败

### ��� 预期效果
- ✅ E2E容器将正确执行@playwright/test
- ✅ 彻底解决ERR_MODULE_NOT_FOUND错误  
- ✅ 真正的根本修复，不再是无用功

### ��� 验证方法
观察日志中不再出现：
- `npm warn exec: playwright@1.55.0 will be installed`
- `Cannot find package '@playwright/test'`