### PR TITLE
fix(docker): 修复docker-compose命令格式问题

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -69,16 +69,16 @@ services:
       - ./frontend/dist:/app/dist
     environment:
       VITE_API_URL: http://backend-test:8000
-    command: |
+    command: >
       bash -c "
-        echo '🚀 启动前端测试服务...'
-        if [ -d '/app/dist' ] && [ -n \"\$(ls -A /app/dist 2>/dev/null)\" ]; then
-          echo '📦 使用构建后的静态文件'
-          cd /app/dist && python3 -m http.server 3000 --bind 0.0.0.0
-        else
-          echo '🔧 使用开发服务器'
-          npm run dev -- --host 0.0.0.0 --port 3000
-        fi
+      echo '🚀 启动前端测试服务...' &&
+      if [ -d '/app/dist' ] && [ -n \"\$(ls -A /app/dist 2>/dev/null)\" ]; then
+        echo '📦 使用构建后的静态文件' &&
+        cd /app/dist && python3 -m http.server 3000 --bind 0.0.0.0;
+      else
+        echo '🔧 使用开发服务器' &&
+        npm run dev -- --host 0.0.0.0 --port 3000;
+      fi
       "
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/"]
@@ -102,17 +102,15 @@ services:
       BACKEND_URL: http://backend-test:8000
       FRONTEND_URL: http://frontend-test:3000
       TEST_BASE_URL: http://frontend-test:3000
-    command: |
+    command: >
       bash -c "
-        echo '⏳ 等待所有服务就绪...'
-        timeout 60 bash -c 'until curl -s http://backend-test:8000/health/; do echo \"等待后端服务...\"; sleep 2; done'
-        timeout 60 bash -c 'until curl -s http://frontend-test:3000/; do echo \"等待前端服务...\"; sleep 2; done'
-
-        echo '🔍 服务状态验证...'
-        echo \"后端服务: \$(curl -s http://backend-test:8000/health/ | head -c 100)\"
-        echo \"前端服务: \$(curl -s http://frontend-test:3000/ | head -c 100)\"
-        echo \"环境变量: TEST_BASE_URL=\$TEST_BASE_URL, FRONTEND_URL=\$FRONTEND_URL\"
-
-        echo '🧪 运行关键E2E测试...'
-        npm run test -- --grep '@critical' --project=chromium
+      echo '⏳ 等待所有服务就绪...' &&
+      timeout 60 bash -c 'until curl -s http://backend-test:8000/health/; do echo \"等待后端服务...\"; sleep 2; done' &&
+      timeout 60 bash -c 'until curl -s http://frontend-test:3000/; do echo \"等待前端服务...\"; sleep 2; done' &&
+      echo '🔍 服务状态验证...' &&
+      echo \"后端服务: \$(curl -s http://backend-test:8000/health/ | head -c 100)\" &&
+      echo \"前端服务: \$(curl -s http://frontend-test:3000/ | head -c 100)\" &&
+      echo \"环境变量: TEST_BASE_URL=\$TEST_BASE_URL, FRONTEND_URL=\$FRONTEND_URL\" &&
+      echo '🧪 运行关键E2E测试...' &&
+      npm run test -- --grep '@critical' --project=chromium
       "


### PR DESCRIPTION
## 问题
- dev分支E2E测试失败，报错：'services[e2e-tests].command' invalid command line string
- docker-compose.test.yml中使用|格式的多行命令在某些版本中不被支持

## 根本原因  
- YAML的|格式与docker-compose某些版本兼容性问题
- 导致E2E和frontend-test服务命令解析失败

## 修复方案
- 将|格式改为>格式
- 使用&&连接多个shell命令
- 保持原有功能逻辑不变

## 测试验证
- [x] 本地docker-compose格式验证
- [ ] GitHub Actions E2E测试
- [ ] 完整CI/CD流程

## 影响
- 修复dev分支E2E测试失败
- 提升CI/CD稳定性
- 保持向后兼容性