### PR TITLE
fix(ci): stabilize regression and e2e on dev

### DIFF
--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -81,7 +81,8 @@ jobs:
         run: |
           echo "Installing MySQL client tools..."
           sudo apt-get update
-          sudo apt-get install -y mysql-client
+          # 仅安装客户端核心工具，避免拉起本机 MySQL Server 与服务容器端口冲突
+          sudo apt-get install -y --no-install-recommends mysql-client-core-8.0
           echo "MySQL client installed successfully"
 
       - name: Setup Test Database
@@ -198,7 +199,7 @@ jobs:
 
           # 确保MySQL和bravo_test数据库完全就绪
           echo "Verifying MySQL and bravo_test database..."
-          MAX_WAIT=30
+          MAX_WAIT=60
           ATTEMPT=0
           until mysql -h 127.0.0.1 -P 3306 -u bravo_user -pbravo_password -e "USE bravo_test; SELECT 1;" >/dev/null 2>&1; do
             ATTEMPT=$((ATTEMPT + 1))

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ coverage.xml
 test-results/
 playwright-report/
 test-results.xml
+_gha_artifacts/
 
 # Docker
 .dockerignore

--- a/frontend/Dockerfile.test
+++ b/frontend/Dockerfile.test
@@ -4,8 +4,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# 安装curl用于健康检查
-RUN apk add --no-cache curl
+# 安装 curl 与 python3（用于静态文件http服务）
+RUN apk add --no-cache curl python3
 
 # 复制 package 文件
 COPY package*.json ./


### PR DESCRIPTION
This PR stabilizes CI on dev:

- frontend(Dockerfile.test): add python3 for static http server fallback in docker-compose e2e
- ci(test-regression): install mysql-client-core only; increase DB readiness wait to 60s to mitigate flakiness
- repo: ignore _gha_artifacts/

Verification:
- feature branch workflow passed (Feature Branch - Development Validation)
- expect Dev Branch workflows to pass after merge

No functional code changes, CI-only adjustments.