### PR TITLE
ci(e2e): use Vite preview in docker-compose to fix frontend-test exit(1)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -76,8 +76,8 @@ services:
       echo '📁 检查构建文件目录...' &&
       ls -la /app/dist/ || echo '构建目录为空' &&
       if [ -d '/app/dist' ] && [ -f '/app/dist/index.html' ]; then
-        echo '📦 使用构建后的静态文件服务' &&
-        cd /app/dist && python3 -m http.server 3000 --bind 0.0.0.0
+        echo '📦 使用构建后的静态文件（Vite preview）' &&
+        npm run preview -- --host 0.0.0.0 --port 3000
       else
         echo '🔧 构建文件不存在，使用开发服务器' &&
         npm run dev -- --host 0.0.0.0 --port 3000


### PR DESCRIPTION
Switch frontend-test static branch from python http.server to Vite preview for consistent app behavior during e2e-critical.

- Changes: docker-compose.test.yml only
- Expected: frontend-test container stays up; e2e-critical passes on dev
- No product code changes