### PR TITLE
ci: fix playwright --verbose parameter - Round10 FINAL

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -123,4 +123,4 @@ services:
         echo "当前工作目录: $(pwd)"
         echo "Playwright配置: $(cat playwright.config.ts | grep baseURL || echo '未找到baseURL配置')"
         echo '🧪 运行关键E2E测试...'
-        npx playwright test --grep '@critical' --project=chromium --reporter=list --verbose
+        npx playwright test --grep '@critical' --project=chromium --reporter=list

--- a/docs/FUCKING_CI.md
+++ b/docs/FUCKING_CI.md
@@ -267,3 +267,32 @@
   - E2E容器可以正确执行playwright测试
   - 服务间连通性完全正常
   - Dev Branch - Optimized Post-Merge Validation 100%成功
+
+---
+
+## 记录项 9
+
+- 北京时间：2025-09-20 15:30:00 CST
+- 第几次推送到 feature：1
+- 第几次 PR：1
+- 第几次 dev post merge：9
+- 关联提交/分支/Run 链接：
+  - commit: 第9轮E2E环境修复合并后
+  - runs:
+    - Dev Branch - Optimized Post-Merge Validation https://github.com/Layneliang24/Bravo/actions/runs/17875801826 (failure)
+- 原因定位：
+  - **重大进展**: exit code从127变为1，证明playwright命令修复成功
+  - **新错误**: error: unknown option '--verbose' - Playwright不支持--verbose参数
+  - **环境差异**: PR验证成功但post-merge失败，说明使用了不同的测试配置
+- 证据：
+  - e2e-tests-1 exited with code 1（而非之前的127）
+  - 明确错误信息：error: unknown option '--verbose'
+  - PR环境史无前例10分钟成功验证vs post-merge环境失败
+- 修复方案：
+  - 移除docker-compose.test.yml中错误的--verbose参数
+  - 使用正确的Playwright命令参数：--reporter=list（无--verbose）
+  - 第7+8+9+10轮组合修复应彻底解决所有CI问题
+- 预期效果：
+  - E2E测试命令完全正确执行
+  - PR和post-merge环境保持一致
+  - Dev Branch - Optimized Post-Merge Validation最终成功


### PR DESCRIPTION
fix final playwright parameter error to complete CI repair journey

## 修复内容

**第10轮最终修复** - 解决最后的playwright参数错误

### ��� 问题分析

**重大进展发现：**
- **之前**: exit code 127 (playwright: not found) 
- **第9轮后**: exit code 1 (playwright可执行，但参数错误)
- **证明**: 第7+8+9轮修复完全成功！

### �� 最终修复

**错误命令：**
```bash
npx playwright test --grep '@critical' --project=chromium --reporter=list --verbose
```

**正确命令：**
```bash  
npx playwright test --grep '@critical' --project=chromium --reporter=list
```

**错误原因：** `--verbose` 不是Playwright的有效参数选项

### ❌ 解决的具体错误

```
error: unknown option '--verbose'
e2e-tests-1 exited with code 1
```

### ✅ 修复历程总结

1. **第7轮**: bash语法错误 ✅
2. **第8轮**: E2E命令格式 ✅  
3. **第9轮**: E2E环境配置 ✅ (playwright命令可执行)
4. **第10轮**: playwright参数错误 ← 最终修复

### ��� 预期效果

**这应该是最后一轮修复：**
- E2E测试命令完全正确
- PR和post-merge环境一致
- **Dev Branch - Optimized Post-Merge Validation 最终成功！**
- **结束多轮CI修复循环！**

### ��� 相关文档

- [FUCKING_CI.md 记录项9](./docs/FUCKING_CI.md) - 详细问题分析
- 完整修复历程记录和验证

### ��� 历史性意义

这是**困扰多轮的CI问题的最终解决方案**，从bash语法到E2E环境配置到最终的参数修复，实现了完整的修复链条。

**期望**: ��� **完全胜利！CI问题彻底解决！**