### PR TITLE
��� 第15轮: 使用npx强制解析playwright命令 - 解决容器环境PATH问题

### DIFF
--- a/.github/workflows/fast-validation.yml
+++ b/.github/workflows/fast-validation.yml
@@ -150,7 +150,7 @@ jobs:
           # 启动所有服务
           if command -v docker-compose >/dev/null 2>&1; then
             echo "启动Docker服务..."
-            docker-compose -f docker-compose.test.yml up --build -d
+            TEST_BASE_URL=http://frontend-test:3000 FRONTEND_URL=http://frontend-test:3000 docker-compose -f docker-compose.test.yml up --build -d
 
             echo "等待E2E测试完成..."
             # 等待e2e-tests容器完成并获取退出码
@@ -185,7 +185,7 @@ jobs:
             fi
           else
             echo "docker-compose not found, using 'docker compose' instead..."
-            docker compose -f docker-compose.test.yml up --build -d
+            TEST_BASE_URL=http://frontend-test:3000 FRONTEND_URL=http://frontend-test:3000 docker compose -f docker-compose.test.yml up --build -d
 
             echo "等待E2E测试完成..."
             if docker compose -f docker-compose.test.yml logs -f e2e-tests; then

--- a/e2e/Dockerfile.test
+++ b/e2e/Dockerfile.test
@@ -58,18 +58,18 @@ RUN npm config set registry https://registry.npmmirror.com/ && \
     npm config set fetch-retry-mintimeout 10000 && \
     npm install --verbose
 
-# 安装Playwright浏览器
-RUN npx playwright install --with-deps
-
 # 复制测试代码
 COPY . .
 
 # 重新安装依赖确保所有文件同步（跳过audit避免404错误）
 RUN npm install --verbose --no-audit
 
-# 设置环境变量
+# 设置环境变量（必须在安装浏览器之前）
 ENV CI=true
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 安装Playwright浏览器（在依赖安装完成后，使用正确的环境变量）
+RUN npx playwright install --with-deps
 
 # 健康检查 - 使用npm script验证安装
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,10 +7,9 @@
     "": {
       "name": "bravo-e2e-tests",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "^1.40.0"
+        "@playwright/test": "^1.55.0"
       },
       "devDependencies": {
         "@types/archiver": "^6.0.3",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -28,7 +28,7 @@
     "show-trace": "playwright show-trace",
     "codegen": "playwright codegen",
     "codegen:blog": "playwright codegen http://localhost:3000/blog",
-    "install": "playwright install",
+    "playwright-install": "playwright install",
     "install:deps": "playwright install-deps",
     "playwright:install": "playwright install",
     "playwright:install-deps": "playwright install-deps",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "playwright test",
+    "test": "npx playwright test",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",
     "test:ui": "playwright test --ui",


### PR DESCRIPTION
## ��� 第15轮发现的新问题

虽然第13轮和第14轮修复都已存在且正常工作，但发现了一个新的容器环境问题！

### 问题分析

#### ✅ 第13轮修复（存在且正常）：
- ✅ `"install"` → `"playwright-install"` 避免npm install冲突
- ✅ Dockerfile.test构建顺序正确

#### ✅ 第14轮修复（存在且生效）：
- ✅ 环境变量正确：`TEST_BASE_URL=http://frontend-test:3000`
- ✅ 服务连通性正常：后端和前端服务都健康

#### ❌ 新发现的问题：
```
> npm run test
> playwright test --grep @critical --project=chromium --reporter=list
sh: 1: playwright: not found
e2e-tests-1 exited with code 127
```

**npm scripts成功执行，但playwright命令仍然找不到！**

### 根本原因

在Docker容器环境中，由于npm workspace依赖提升机制：
1. `@playwright/test`安装在workspace根目录
2. 容器内的PATH无法正确解析playwright命令位置
3. 即使npm scripts能解析package.json，实际执行时还是找不到二进制文件

### 解决方案

**使用`npx`强制从node_modules解析playwright：**

```diff
- "test": "playwright test",
+ "test": "npx playwright test",
```

### 预期效果

- `npx`强制从本地node_modules查找playwright
- 避免依赖系统PATH解析
- 解决容器环境中的命令找不到问题
- 结合第13轮和第14轮修复，最终彻底解决CI问题

**这是基于前14轮修复的最终完善，应该能彻底解决问题！**