### PR TITLE
fix: 第24轮修复fast-validation.yml中docker-compose兼容性问题

### DIFF
--- a/.github/workflows/fast-validation.yml
+++ b/.github/workflows/fast-validation.yml
@@ -151,17 +151,17 @@ jobs:
           if command -v docker-compose >/dev/null 2>&1; then
             echo "启动Docker服务..."
             # 🎯 最优方案：移除环境变量传递，容器自给自足
-            docker-compose -f docker-compose.test.yml up --build -d
+            docker compose -f docker-compose.test.yml up --build -d
 
             echo "等待E2E测试完成..."
             # 🎯 彻底修复：使用直接的容器退出码检测
 
             # 等待e2e-tests容器完成，获取其退出码
             echo "等待E2E容器完成..."
-            docker-compose -f docker-compose.test.yml logs -f e2e-tests || true
+            docker compose -f docker-compose.test.yml logs -f e2e-tests || true
 
             # 直接获取容器退出码，不依赖if分支
-            E2E_CID=$(docker-compose -f docker-compose.test.yml ps -q e2e-tests)
+            E2E_CID=$(docker compose -f docker-compose.test.yml ps -q e2e-tests)
             echo "E2E容器ID: $E2E_CID"
 
             if [ -n "$E2E_CID" ]; then
@@ -184,21 +184,21 @@ jobs:
             fi
 
             echo "清理Docker服务..."
-            docker-compose -f docker-compose.test.yml down
+            docker compose -f docker-compose.test.yml down
 
             exit $E2E_EXIT_CODE
             else
               echo "Docker Compose日志获取失败，使用传统方法..."
-              docker-compose -f docker-compose.test.yml up --build --exit-code-from e2e-tests || true
+              docker compose -f docker-compose.test.yml up --build --exit-code-from e2e-tests || true
               echo "📦 收集E2E测试产物(传统路径)..."
               mkdir -p e2e-artifacts || true
-              E2E_CID=$(docker-compose -f docker-compose.test.yml ps -q e2e-tests)
+              E2E_CID=$(docker compose -f docker-compose.test.yml ps -q e2e-tests)
               if [ -n "$E2E_CID" ]; then
                 docker cp "$E2E_CID:/app/test-results" e2e-artifacts/test-results 2>/dev/null || true
                 docker cp "$E2E_CID:/app/playwright-report" e2e-artifacts/playwright-report 2>/dev/null || true
                 docker cp "$E2E_CID:/app/e2e-results.xml" e2e-artifacts/e2e-results.xml 2>/dev/null || true
               fi
-              docker-compose -f docker-compose.test.yml down
+              docker compose -f docker-compose.test.yml down
             fi
           else
             echo "docker-compose not found, using 'docker compose' instead..."


### PR DESCRIPTION
��� 第24轮修复：解决post-merge环境docker-compose兼容性

## 问题分析
- post-merge工作流失败，exit code 127 (command not found)
- fast-validation.yml第一个if分支仍使用docker-compose
- 导致PR环境成功但post-merge环境失败

## 修复内容
✅ 统一所有docker-compose命令为docker compose：
- 第154行：主要逻辑命令
- 第161行：logs命令
- 第164行：ps命令 
- 第187行：down命令
- 第192行：传统方法fallback
- 第195行：传统方法ps命令
- 第201行：传统方法down命令

## 预期效果
- 消除post-merge环境command not found错误
- 统一PR和post-merge环境Docker Compose兼容性
- 第24轮彻底解决所有docker-compose兼容性问题