### PR TITLE
fix: 第25轮修复fast-validation.yml中的bash语法错误

### DIFF
--- a/.github/workflows/fast-validation.yml
+++ b/.github/workflows/fast-validation.yml
@@ -187,19 +187,6 @@ jobs:
             docker compose -f docker-compose.test.yml down
 
             exit $E2E_EXIT_CODE
-            else
-              echo "Docker Compose日志获取失败，使用传统方法..."
-              docker compose -f docker-compose.test.yml up --build --exit-code-from e2e-tests || true
-              echo "📦 收集E2E测试产物(传统路径)..."
-              mkdir -p e2e-artifacts || true
-              E2E_CID=$(docker compose -f docker-compose.test.yml ps -q e2e-tests)
-              if [ -n "$E2E_CID" ]; then
-                docker cp "$E2E_CID:/app/test-results" e2e-artifacts/test-results 2>/dev/null || true
-                docker cp "$E2E_CID:/app/playwright-report" e2e-artifacts/playwright-report 2>/dev/null || true
-                docker cp "$E2E_CID:/app/e2e-results.xml" e2e-artifacts/e2e-results.xml 2>/dev/null || true
-              fi
-              docker compose -f docker-compose.test.yml down
-            fi
           else
             echo "docker-compose not found, using 'docker compose' instead..."
             # 🎯 最优方案：移除环境变量传递，容器自给自足
@@ -239,19 +226,6 @@ jobs:
             docker compose -f docker-compose.test.yml down
 
             exit $E2E_EXIT_CODE
-          else
-              echo "Docker Compose日志获取失败，使用传统方法..."
-              docker compose -f docker-compose.test.yml up --build --exit-code-from e2e-tests || true
-              echo "📦 收集E2E测试产物(传统路径)..."
-              mkdir -p e2e-artifacts || true
-              E2E_CID=$(docker compose -f docker-compose.test.yml ps -q e2e-tests)
-              if [ -n "$E2E_CID" ]; then
-                docker cp "$E2E_CID:/app/test-results" e2e-artifacts/test-results 2>/dev/null || true
-                docker cp "$E2E_CID:/app/playwright-report" e2e-artifacts/playwright-report 2>/dev/null || true
-                docker cp "$E2E_CID:/app/e2e-results.xml" e2e-artifacts/e2e-results.xml 2>/dev/null || true
-              fi
-              docker compose -f docker-compose.test.yml down
-            fi
           fi
 
       - name: Upload E2E Artifacts (fast-validation)

--- a/.github/workflows/fast-validation.yml
+++ b/.github/workflows/fast-validation.yml
@@ -151,17 +151,17 @@ jobs:
           if command -v docker-compose >/dev/null 2>&1; then
             echo "启动Docker服务..."
             # 🎯 最优方案：移除环境变量传递，容器自给自足
-            docker-compose -f docker-compose.test.yml up --build -d
+            docker compose -f docker-compose.test.yml up --build -d
 
             echo "等待E2E测试完成..."
             # 🎯 彻底修复：使用直接的容器退出码检测
 
             # 等待e2e-tests容器完成，获取其退出码
             echo "等待E2E容器完成..."
-            docker-compose -f docker-compose.test.yml logs -f e2e-tests || true
+            docker compose -f docker-compose.test.yml logs -f e2e-tests || true
 
             # 直接获取容器退出码，不依赖if分支
-            E2E_CID=$(docker-compose -f docker-compose.test.yml ps -q e2e-tests)
+            E2E_CID=$(docker compose -f docker-compose.test.yml ps -q e2e-tests)
             echo "E2E容器ID: $E2E_CID"
 
             if [ -n "$E2E_CID" ]; then
@@ -184,21 +184,21 @@ jobs:
             fi
 
             echo "清理Docker服务..."
-            docker-compose -f docker-compose.test.yml down
+            docker compose -f docker-compose.test.yml down
 
             exit $E2E_EXIT_CODE
             else
               echo "Docker Compose日志获取失败，使用传统方法..."
-              docker-compose -f docker-compose.test.yml up --build --exit-code-from e2e-tests || true
+              docker compose -f docker-compose.test.yml up --build --exit-code-from e2e-tests || true
               echo "📦 收集E2E测试产物(传统路径)..."
               mkdir -p e2e-artifacts || true
-              E2E_CID=$(docker-compose -f docker-compose.test.yml ps -q e2e-tests)
+              E2E_CID=$(docker compose -f docker-compose.test.yml ps -q e2e-tests)
               if [ -n "$E2E_CID" ]; then
                 docker cp "$E2E_CID:/app/test-results" e2e-artifacts/test-results 2>/dev/null || true
                 docker cp "$E2E_CID:/app/playwright-report" e2e-artifacts/playwright-report 2>/dev/null || true
                 docker cp "$E2E_CID:/app/e2e-results.xml" e2e-artifacts/e2e-results.xml 2>/dev/null || true
               fi
-              docker-compose -f docker-compose.test.yml down
+              docker compose -f docker-compose.test.yml down
             fi
           else
             echo "docker-compose not found, using 'docker compose' instead..."


### PR DESCRIPTION
��� **紧急语法修复**：第24轮修复引入了bash语法错误

## ��� 问题根本原因
- 第190行多余的else语句不属于任何if
- 第229行重复的else分支导致bash语法错误
- GitHub Actions报告：syntax error near unexpected token else

## ��� 本地验证已完成
- ✅ bash语法检查通过
- ✅ docker-compose配置验证通过  
- ✅ 移除所有悬挂的else语句

## ��� 修复内容
- 删除第190-202行：错误的else分支
- 删除第229-241行：重复的代码块
- 确保if-else-fi结构正确匹配

## ��� 预期效果
- 彻底解决exit code 2语法错误
- E2E测试能正常执行而不是语法失败
- 第25轮bash语法修复成功