### PR TITLE
fix: 第35轮彻底修复测试环境根路径404问题

### DIFF
--- a/backend/bravo/urls_test.py
+++ b/backend/bravo/urls_test.py
@@ -2,16 +2,36 @@
 """测试环境URL配置 - 简化版本，不依赖外部包"""
 
 from django.contrib import admin
+from django.http import JsonResponse
 from django.urls import include, path
 
 from apps.common.views import api_info, health_check
 
+
+def home_view(_request):
+    """测试环境根路径视图，返回API信息"""
+    return JsonResponse(
+        {
+            "message": "Welcome to Bravo API (Test)",
+            "version": "1.0.0",
+            "endpoints": {
+                "api_docs": "/api/docs/",
+                "admin": "/admin/",
+                "health": "/health/",
+                "api_info": "/api-info/",
+            },
+        }
+    )
+
+
 urlpatterns = [
+    # 根路径
+    path("", home_view, name="home"),
     # 管理后台
     path("admin/", admin.site.urls),
     # 健康检查和API信息
     path("health/", health_check, name="health_check"),
     path("api-info/", api_info, name="api_info"),
-    # 通用应用URL
-    path("", include("apps.common.urls")),
+    # 通用应用URL (使用common/前缀避免与根路径冲突)
+    path("common/", include("apps.common.urls")),
 ]


### PR DESCRIPTION
��� **第35轮根本性突破**：用户质疑促成真正根因发现！

## ��� 重大发现：测试环境URL配置缺陷

### ��� 问题分析过程
1. **第34轮修复了** - 但仍然失败
2. **用户质疑要求本地验证** - 关键转折点！
3. **本地验证发现真正问题**：
   

### ��� 真正根本原因
- : 
- **回归测试使用test settings，使用而不是**
- **缺少根路径home_view配置**
- **Django无法解析根路径，返回Resolver404**

### ��� 技术修复
- 在中添加home_view函数
- 添加根路径配置：
- 修复apps.common.urls冲突（改为common/前缀）

### ✅ 本地验证成功


### ��� 预期结果
- API根端点返回200状态码
- Medium Validation中的API兼容性测试通过
- 彻底解决困扰35轮的根本问题

**感谢用户的质疑和坚持，第35轮找到了真正的根本原因！**