### PR TITLE
��� hotfix: 修复npm ci导致的E2E测试失败

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: npm ci
+        run: npm install
 
       # 使用统一的缓存设置（包含Playwright浏览器缓存）
       - name: Setup E2E Cache


### PR DESCRIPTION
## ��� 紧急修复

### 问题描述
PR #99的npm ci优化导致了E2E Tests (Full Suite)失败，影响了dev分支的稳定性。

### ��� 问题分析  
- **失败工作流**: Dev Branch - Medium Validation
- **失败节点**: Run Full E2E Test Suite  
- **根本原因**: npm ci在E2E环境下与npm install行为有细微差别

### ��� 证据对比
- **修改前**: Dev Branch - Medium Validation ✅ 成功
- **修改后**: Dev Branch - Medium Validation ❌ 失败
- **失败链接**: https://github.com/Layneliang24/Bravo/actions/runs/17911527800/job/50924461604

### ��� 修复方案
恢复E2E相关工作流中的npm install，保留其他优化：

- **恢复文件**:
  - test-e2e-full.yml: e2e目录依赖安装
  - test-e2e.yml: frontend和e2e目录依赖安装
- **保留优化**: 根目录和其他工作流的npm ci优化

### ⚡ 紧急程度
- ��� **高**: 影响dev分支主要验证流程
- ��� **阻塞**: E2E测试失败阻止正常开发流程

### ��� 预期效果
- ✅ 恢复E2E测试正常运行
- ✅ 保持大部分npm ci性能优化  
- ✅ 确保dev分支验证流程稳定

### ��� 后续计划
1. 合并此修复，恢复dev分支稳定性
2. 研究E2E环境下npm ci vs npm install差异
3. 制定E2E相关依赖优化的专项方案