### PR TITLE
fix(deps): 添加django-extensions解决Integration Smoke Test失败

### DIFF
--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -32,6 +32,7 @@ flake8==6.0.0
 
 # 调试工具（防止CI环境导入错误）
 django-debug-toolbar==4.2.0
+django-extensions==3.2.3
 
 # 数据库配置
 dj-database-url==2.1.0


### PR DESCRIPTION
## ��� 第二个依赖修复：django-extensions缺失

### ��� 问题背景

在成功解决flake8问题后，发现新的Integration Smoke Test失败：

#### ❌ 错误现象
```
ModuleNotFoundError: No module named 'django_extensions'
```

#### ��� 根因分析

**配置不一致问题**：
- `test.py` 设置了 `DEBUG = True`
- `local.py` 有条件逻辑：`if DEBUG: INSTALLED_APPS += ['django_extensions', ...]`
- `django-extensions==3.2.3` 在 `local.txt` 中定义
- 但 `test.txt` 缺少此依赖，导致导入失败

**逻辑链条**：
1. CI使用 `test.py` 配置，设置 `DEBUG = True`
2. Django加载时触发 `local.py` 的DEBUG条件逻辑
3. 尝试加载 `django_extensions` 到 `INSTALLED_APPS`
4. 模块不存在，导致 `ModuleNotFoundError`

### ✅ 修复方案

**添加缺失依赖**：
```diff
# 调试工具（防止CI环境导入错误）
django-debug-toolbar==4.2.0
+ django-extensions==3.2.3
```

**版本一致性**：
- 使用与 `local.txt` 相同的版本：`==3.2.3`
- 确保test/local环境DEBUG工具依赖一致

### ��� 修复效果预期

1. **解决Integration Smoke Test**：消除 `django_extensions` 导入错误
2. **环境一致性**：test和local环境DEBUG工具保持同步
3. **完整验证**：配合之前的缓存修复，彻底解决dev分支post-merge验证问题

### ��� 技术洞察

这次修复展示了重要的配置管理原则：

1. **环境一致性**：相同的DEBUG设置应该有相同的依赖
2. **条件依赖管理**：`if DEBUG` 逻辑要求对应的依赖在所有DEBUG环境中可用
3. **渐进式修复**：先解决缓存问题(flake8)，再解决配置问题(django_extensions)

### ��� 验证状态

#### ✅ 已解决问题
- flake8问题：通过缓存升级(v3→v4)解决
- django-debug-toolbar问题：已添加到test.txt

#### �� 当前修复
- django-extensions问题：添加到test.txt

#### ��� 预期结果
- Dev Branch post-merge验证完全通过
- Integration Smoke Test成功
- 所有DEBUG工具依赖完整

### ��� 影响范围

- ✅ 修复 Integration Smoke Test
- ✅ 完善 test 环境 DEBUG 工具依赖
- ✅ 保持 test/local 环境配置一致性
- ✅ 彻底解决 dev 分支 post-merge 验证失败