### PR TITLE
fix(cache): 强制刷新缓存确保django-extensions被安装

### DIFF
--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -34,5 +34,7 @@ flake8==6.0.0
 django-debug-toolbar==4.2.0
 django-extensions==3.2.3
 
+# 强制缓存刷新 - 确保虚拟环境包含django-extensions (2025-09-23)
+
 # 数据库配置
 dj-database-url==2.1.0


### PR DESCRIPTION
## ��� 紧急缓存修复

### 问题根因
- dev分支post-merge CI仍然失败：
- 使用了旧缓存key: 
- 虽然requirements文件包含django-extensions，但缓存哈希未变

### 修复方案
在中添加注释，强制改变文件哈希：


### 预期结果
- 新的缓存key将被生成
- 虚拟环境将重新构建，包含django-extensions
- dev分支post-merge CI将通过

### 前置修复
这是PR #108的补充修复，解决缓存刷新问题。