### PR TITLE
fix(ci): 增强智能依赖检测 - 多包检查解决silk错误

### DIFF
--- a/.github/actions/setup-cached-env/action.yml
+++ b/.github/actions/setup-cached-env/action.yml
@@ -55,12 +55,30 @@ runs:
         else
           echo "🔍 检查现有虚拟环境中的关键依赖..."
           source .venv/bin/activate
-          # 检查django_extensions是否存在（这是最常失败的包）
+          # 检查多个关键依赖包
+          MISSING_PACKAGES=""
+
+          # 检查django_extensions
           if ! python -c "import django_extensions" 2>/dev/null; then
-            echo "❌ django_extensions缺失，需要重新安装依赖"
+            MISSING_PACKAGES="$MISSING_PACKAGES django_extensions"
+          fi
+
+          # 检查silk (性能分析工具)
+          if ! python -c "import silk" 2>/dev/null; then
+            MISSING_PACKAGES="$MISSING_PACKAGES silk"
+          fi
+
+          # 检查debug_toolbar
+          if ! python -c "import debug_toolbar" 2>/dev/null; then
+            MISSING_PACKAGES="$MISSING_PACKAGES debug_toolbar"
+          fi
+
+          if [ -n "$MISSING_PACKAGES" ]; then
+            echo "❌ 关键依赖缺失:$MISSING_PACKAGES"
+            echo "需要重新安装依赖确保环境完整"
             NEED_INSTALL=true
           else
-            echo "✅ 关键依赖存在，跳过安装"
+            echo "✅ 所有关键依赖存在，跳过安装"
             NEED_INSTALL=false
           fi
         fi


### PR DESCRIPTION
## ��� 基于最新失败分析的改进

### 发现的新问题
- PR #111的django_extensions检测**工作正常** ✅
- 但出现了新错误：`ModuleNotFoundError: No module named 'silk'` ❌
- 说明需要检查更多关键依赖包

### ��� 增强的智能检测
现在检查**3个关键包**：
- `django_extensions`
- `silk` (性能分析工具)  
- `debug_toolbar`

### ��� 改进逻辑
```bash
# 检查多个关键依赖包
MISSING_PACKAGES=""
if ! python -c "import django_extensions"; then
  MISSING_PACKAGES="$MISSING_PACKAGES django_extensions"
fi
if ! python -c "import silk"; then
  MISSING_PACKAGES="$MISSING_PACKAGES silk"
fi
# 任何一个缺失都触发完整重新安装
```

### ✅ 预期效果
- 解决silk包缺失错误
- 确保所有关键依赖完整安装
- Post-Merge工作流成功通过

基于PR #111的成功基础进行增强