### PR TITLE
fix: 修复setup-cache超时导致工作流取消问题

### DIFF
--- a/.github/workflows/setup-cache.yml
+++ b/.github/workflows/setup-cache.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   setup-cache:
     runs-on: ubuntu-latest
-    timeout-minutes: 5 # 🚀 Phase 4: 减少超时时间以加快失败检测
+    timeout-minutes: 10 # 🔧 临时增加超时时间，解决偶发性网络延迟问题
 
     outputs:
       frontend-cache-hit: ${{ steps.frontend-cache.outputs.cache-hit }}


### PR DESCRIPTION
## ��� 修复超时问题

### 问题描述
- setup-cache步骤运行时间：5分16秒
- 当前超时限制：5分钟  
- 导致整个Branch Protection工作流被取消

### 解决方案
- 将timeout从5分钟增加到10分钟
- 临时解决偶发性网络延迟问题

### 影响
- ✅ 修复PR #143的CI检查问题
- ✅ 防止工作流因网络延迟被取消
- ✅ 不影响其他工作流的运行时间

### 相关链接
- 失败的工作流：https://github.com/Layneliang24/Bravo/actions/runs/18027572875
- 相关PR：#143