### PR TITLE
fix(api): 修复验证码刷新API的400错误

### DIFF
--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -155,8 +155,14 @@ class CaptchaRefreshAPIView(BaseCaptchaView):
         返回:
             Response: 包含新的captcha_id, captcha_image, expires_in的JSON响应
         """
+        # 验证请求数据（可选字段，允许空请求体）
+        serializer = CaptchaRefreshRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            # 如果验证失败，返回400错误
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
         # 如果提供了旧的captcha_id，删除旧的验证码（可选）
-        old_captcha_id = request.data.get("captcha_id")
+        old_captcha_id = serializer.validated_data.get("captcha_id")
         if old_captcha_id:
             # 记录删除操作，用于调试
             import logging

--- a/backend/coverage.json
+++ b/backend/coverage.json
@@ -1,25 +1,62 @@
 {
   "meta": {
-    "version": "7.3.2",
-    "timestamp": "2025-12-17T13:39:54.958505",
+    "format": 3,
+    "version": "7.12.0",
+    "timestamp": "2025-12-21T13:27:17.169556",
     "branch_coverage": false,
     "show_contexts": false
   },
   "files": {
-    "apps\\__init__.py": {
-      "executed_lines": [1],
+    "apps/__init__.py": {
+      "executed_lines": [0],
       "summary": {
         "covered_lines": 0,
         "num_statements": 0,
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\blog\\__init__.py": {
+    "apps/blog/__init__.py": {
       "executed_lines": [],
       "summary": {
         "covered_lines": 0,
@@ -27,12 +64,48 @@
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\blog\\urls.py": {
+    "apps/blog/urls.py": {
       "executed_lines": [],
       "summary": {
         "covered_lines": 0,
@@ -40,145 +113,97 @@
         "percent_covered": 0.0,
         "percent_covered_display": "0.00",
         "missing_lines": 2,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
       },
       "missing_lines": [2, 5],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [2, 5],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [2, 5],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\common\\__init__.py": {
-      "executed_lines": [1],
+    "apps/common/__init__.py": {
+      "executed_lines": [0],
       "summary": {
         "covered_lines": 0,
         "num_statements": 0,
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\common\\pagination.py": {
-      "executed_lines": [3, 6, 7, 9, 10, 11],
-      "summary": {
-        "covered_lines": 5,
-        "num_statements": 5,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
       },
-      "missing_lines": [],
-      "excluded_lines": []
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\common\\urls.py": {
-      "executed_lines": [1, 3, 5, 7],
-      "summary": {
-        "covered_lines": 3,
-        "num_statements": 3,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\common\\views.py": {
-      "executed_lines": [
-        1, 3, 4, 5, 8, 9, 10, 12, 14, 15, 16, 17, 18, 20, 27, 28, 29, 32, 33,
-        34, 36, 37, 38, 39, 40, 41, 43, 55, 56, 57
-      ],
-      "summary": {
-        "covered_lines": 29,
-        "num_statements": 29,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\english\\__init__.py": {
-      "executed_lines": [],
-      "summary": {
-        "covered_lines": 0,
-        "num_statements": 0,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\english\\urls.py": {
-      "executed_lines": [],
-      "summary": {
-        "covered_lines": 0,
-        "num_statements": 2,
-        "percent_covered": 0.0,
-        "percent_covered_display": "0.00",
-        "missing_lines": 2,
-        "excluded_lines": 0
-      },
-      "missing_lines": [2, 5],
-      "excluded_lines": []
-    },
-    "apps\\example\\views.py": {
-      "executed_lines": [2, 3],
-      "summary": {
-        "covered_lines": 2,
-        "num_statements": 2,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\feature_flags\\__init__.py": {
-      "executed_lines": [],
-      "summary": {
-        "covered_lines": 0,
-        "num_statements": 1,
-        "percent_covered": 0.0,
-        "percent_covered_display": "0.00",
-        "missing_lines": 1,
-        "excluded_lines": 0
-      },
-      "missing_lines": [2],
-      "excluded_lines": []
-    },
-    "apps\\feature_flags\\apps.py": {
-      "executed_lines": [],
-      "summary": {
-        "covered_lines": 0,
-        "num_statements": 6,
-        "percent_covered": 0.0,
-        "percent_covered_display": "0.00",
-        "missing_lines": 6,
-        "excluded_lines": 0
-      },
-      "missing_lines": [2, 4, 7, 10, 11, 12],
-      "excluded_lines": []
-    },
-    "apps\\feature_flags\\models.py": {
-      "executed_lines": [],
-      "summary": {
-        "covered_lines": 0,
-        "num_statements": 14,
-        "percent_covered": 0.0,
-        "percent_covered_display": "0.00",
-        "missing_lines": 14,
-        "excluded_lines": 0
-      },
-      "missing_lines": [2, 4, 7, 10, 11, 12, 13, 14, 16, 17, 18, 19, 21, 22],
-      "excluded_lines": []
-    },
-    "apps\\feature_flags\\urls.py": {
+    "apps/common/pagination.py": {
       "executed_lines": [],
       "summary": {
         "covered_lines": 0,
@@ -186,25 +211,323 @@
         "percent_covered": 0.0,
         "percent_covered_display": "0.00",
         "missing_lines": 5,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
       },
-      "missing_lines": [2, 4, 6, 8, 10],
-      "excluded_lines": []
+      "missing_lines": [3, 6, 9, 10, 11],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [3, 6, 9, 10, 11],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "StandardResultsSetPagination": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [3, 6, 9, 10, 11],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\feature_flags\\views.py": {
-      "executed_lines": [],
+    "apps/common/urls.py": {
+      "executed_lines": [1, 3, 5, 7],
       "summary": {
-        "covered_lines": 0,
-        "num_statements": 4,
-        "percent_covered": 0.0,
-        "percent_covered_display": "0.00",
-        "missing_lines": 4,
-        "excluded_lines": 0
+        "covered_lines": 3,
+        "num_statements": 3,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100.00",
+        "missing_lines": 0,
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
-      "missing_lines": [2, 4, 7, 9],
-      "excluded_lines": []
+      "missing_lines": [],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [1, 3, 5, 7],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 3,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [1, 3, 5, 7],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 3,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\jobs\\__init__.py": {
+    "apps/common/views.py": {
+      "executed_lines": [
+        1, 3, 5, 6, 7, 8, 9, 12, 13, 15, 17, 33, 35, 42, 43, 44, 46, 50, 60, 62,
+        63, 66, 67, 69, 71, 98, 116, 120, 130
+      ],
+      "summary": {
+        "covered_lines": 26,
+        "num_statements": 44,
+        "percent_covered": 59.09090909090909,
+        "percent_covered_display": "59.09",
+        "missing_lines": 18,
+        "excluded_lines": 0,
+        "percent_statements_covered": 59.09090909090909,
+        "percent_statements_covered_display": "59.09"
+      },
+      "missing_lines": [
+        48, 52, 53, 54, 55, 56, 100, 112, 113, 114, 118, 122, 123, 124, 125,
+        126, 132, 133
+      ],
+      "excluded_lines": [],
+      "functions": {
+        "HealthCheckView.get": {
+          "executed_lines": [35, 42, 43, 44],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "HealthCheckView.post": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [48],
+          "excluded_lines": []
+        },
+        "HealthCheckView.options": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [52, 53, 54, 55, 56],
+          "excluded_lines": []
+        },
+        "health_check": {
+          "executed_lines": [62, 63],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 2,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "ApiInfoView.get": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 4,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 4,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [100, 112, 113, 114],
+          "excluded_lines": []
+        },
+        "ApiInfoView.post": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [118],
+          "excluded_lines": []
+        },
+        "ApiInfoView.options": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [122, 123, 124, 125, 126],
+          "excluded_lines": []
+        },
+        "api_info": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [132, 133],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            1, 3, 5, 6, 7, 8, 9, 12, 13, 15, 17, 33, 46, 50, 60, 66, 67, 69, 71,
+            98, 116, 120, 130
+          ],
+          "summary": {
+            "covered_lines": 20,
+            "num_statements": 20,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "HealthCheckView": {
+          "executed_lines": [35, 42, 43, 44],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 10,
+            "percent_covered": 40.0,
+            "percent_covered_display": "40.00",
+            "missing_lines": 6,
+            "excluded_lines": 0,
+            "percent_statements_covered": 40.0,
+            "percent_statements_covered_display": "40.00"
+          },
+          "missing_lines": [48, 52, 53, 54, 55, 56],
+          "excluded_lines": []
+        },
+        "ApiInfoView": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 10,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 10,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [100, 112, 113, 114, 118, 122, 123, 124, 125, 126],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            1, 3, 5, 6, 7, 8, 9, 12, 13, 15, 17, 33, 46, 50, 60, 62, 63, 66, 67,
+            69, 71, 98, 116, 120, 130
+          ],
+          "summary": {
+            "covered_lines": 22,
+            "num_statements": 24,
+            "percent_covered": 91.66666666666667,
+            "percent_covered_display": "91.67",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 91.66666666666667,
+            "percent_statements_covered_display": "91.67"
+          },
+          "missing_lines": [132, 133],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/english/__init__.py": {
       "executed_lines": [],
       "summary": {
         "covered_lines": 0,
@@ -212,12 +535,48 @@
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\jobs\\urls.py": {
+    "apps/english/urls.py": {
       "executed_lines": [],
       "summary": {
         "covered_lines": 0,
@@ -225,77 +584,530 @@
         "percent_covered": 0.0,
         "percent_covered_display": "0.00",
         "missing_lines": 2,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
       },
       "missing_lines": [2, 5],
-      "excluded_lines": []
-    },
-    "apps\\test_optimized\\views.py": {
-      "executed_lines": [2, 3],
-      "summary": {
-        "covered_lines": 2,
-        "num_statements": 2,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [2, 5],
+          "excluded_lines": []
+        }
       },
-      "missing_lines": [],
-      "excluded_lines": []
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [2, 5],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\test_scenario2\\views.py": {
-      "executed_lines": [2, 3],
-      "summary": {
-        "covered_lines": 2,
-        "num_statements": 2,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\test_scenario3\\views.py": {
-      "executed_lines": [2, 3],
-      "summary": {
-        "covered_lines": 2,
-        "num_statements": 2,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\test_t01\\views.py": {
-      "executed_lines": [2, 3],
-      "summary": {
-        "covered_lines": 2,
-        "num_statements": 2,
-        "percent_covered": 100.0,
-        "percent_covered_display": "100.00",
-        "missing_lines": 0,
-        "excluded_lines": 0
-      },
-      "missing_lines": [],
-      "excluded_lines": []
-    },
-    "apps\\users\\__init__.py": {
-      "executed_lines": [1],
+    "apps/feature_flags/__init__.py": {
+      "executed_lines": [2],
       "summary": {
         "covered_lines": 0,
         "num_statements": 0,
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [2],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [2],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\admin.py": {
+    "apps/feature_flags/apps.py": {
+      "executed_lines": [],
+      "summary": {
+        "covered_lines": 0,
+        "num_statements": 5,
+        "percent_covered": 0.0,
+        "percent_covered_display": "0.00",
+        "missing_lines": 5,
+        "excluded_lines": 0,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
+      },
+      "missing_lines": [4, 7, 10, 11, 12],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [4, 7, 10, 11, 12],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "FeatureFlagsConfig": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [4, 7, 10, 11, 12],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/feature_flags/models.py": {
+      "executed_lines": [],
+      "summary": {
+        "covered_lines": 0,
+        "num_statements": 13,
+        "percent_covered": 0.0,
+        "percent_covered_display": "0.00",
+        "missing_lines": 13,
+        "excluded_lines": 0,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
+      },
+      "missing_lines": [4, 7, 10, 11, 12, 13, 14, 16, 17, 18, 19, 21, 22],
+      "excluded_lines": [],
+      "functions": {
+        "FeatureFlag.__str__": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [22],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 12,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 12,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [4, 7, 10, 11, 12, 13, 14, 16, 17, 18, 19, 21],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "FeatureFlag": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [22],
+          "excluded_lines": []
+        },
+        "FeatureFlag.Meta": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 12,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 12,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [4, 7, 10, 11, 12, 13, 14, 16, 17, 18, 19, 21],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/feature_flags/urls.py": {
+      "executed_lines": [2, 4, 6, 8, 10],
+      "summary": {
+        "covered_lines": 4,
+        "num_statements": 4,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100.00",
+        "missing_lines": 0,
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
+      },
+      "missing_lines": [],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [2, 4, 6, 8, 10],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [2, 4, 6, 8, 10],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/feature_flags/views.py": {
+      "executed_lines": [2, 4, 5, 6, 7, 10, 11, 13, 15, 32],
+      "summary": {
+        "covered_lines": 8,
+        "num_statements": 9,
+        "percent_covered": 88.88888888888889,
+        "percent_covered_display": "88.89",
+        "missing_lines": 1,
+        "excluded_lines": 0,
+        "percent_statements_covered": 88.88888888888889,
+        "percent_statements_covered_display": "88.89"
+      },
+      "missing_lines": [34],
+      "excluded_lines": [],
+      "functions": {
+        "FeatureFlagsStatusView.get": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [34],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [2, 4, 5, 6, 7, 10, 11, 13, 15, 32],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 8,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "FeatureFlagsStatusView": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [34],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [2, 4, 5, 6, 7, 10, 11, 13, 15, 32],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 8,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/jobs/__init__.py": {
+      "executed_lines": [],
+      "summary": {
+        "covered_lines": 0,
+        "num_statements": 0,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100.00",
+        "missing_lines": 0,
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
+      },
+      "missing_lines": [],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/jobs/urls.py": {
+      "executed_lines": [],
+      "summary": {
+        "covered_lines": 0,
+        "num_statements": 2,
+        "percent_covered": 0.0,
+        "percent_covered_display": "0.00",
+        "missing_lines": 2,
+        "excluded_lines": 0,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
+      },
+      "missing_lines": [2, 5],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [2, 5],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [2, 5],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/users/__init__.py": {
+      "executed_lines": [0],
+      "summary": {
+        "covered_lines": 0,
+        "num_statements": 0,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100.00",
+        "missing_lines": 0,
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
+      },
+      "missing_lines": [],
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/users/admin.py": {
       "executed_lines": [
         3, 5, 6, 7, 8, 11, 12, 13, 15, 26, 33, 34, 35, 37, 39, 64, 66, 67, 80,
         81, 92, 93, 94, 96, 107, 112, 113, 114, 115, 117, 140, 152, 154, 160,
@@ -304,12 +1116,14 @@
         271, 273, 279, 280, 284, 285, 286
       ],
       "summary": {
-        "covered_lines": 66,
-        "num_statements": 120,
-        "percent_covered": 55.0,
-        "percent_covered_display": "55.00",
+        "covered_lines": 65,
+        "num_statements": 119,
+        "percent_covered": 54.621848739495796,
+        "percent_covered_display": "54.62",
         "missing_lines": 54,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 54.621848739495796,
+        "percent_statements_covered_display": "54.62"
       },
       "missing_lines": [
         69, 71, 72, 73, 74, 75, 76, 77, 78, 83, 84, 85, 86, 142, 143, 144, 150,
@@ -317,155 +1131,2077 @@
         195, 196, 201, 203, 204, 205, 206, 236, 237, 238, 244, 250, 251, 252,
         258, 259, 260, 266, 267, 268, 275, 276, 277
       ],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "UserAdmin.mark_email_verified": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 9,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 9,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [69, 71, 72, 73, 74, 75, 76, 77, 78],
+          "excluded_lines": []
+        },
+        "UserAdmin.delete_unverified_users": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 4,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 4,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [83, 84, 85, 86],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin.user_link": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 4,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 4,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [142, 143, 144, 150],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin.token_short": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [156, 157, 158],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin.is_verified": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [164, 165, 166],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin.is_expired": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [173, 174, 175],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin.resend_verification_email": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 7,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [185, 187, 188, 189, 190, 195, 196],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin.delete_expired_verifications": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 5,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [201, 203, 204, 205, 206],
+          "excluded_lines": []
+        },
+        "PasswordResetAdmin.user_link": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 4,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 4,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [236, 237, 238, 244],
+          "excluded_lines": []
+        },
+        "PasswordResetAdmin.user_email": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [250, 251, 252],
+          "excluded_lines": []
+        },
+        "PasswordResetAdmin.token_short": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [258, 259, 260],
+          "excluded_lines": []
+        },
+        "PasswordResetAdmin.is_used": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [266, 267, 268],
+          "excluded_lines": []
+        },
+        "PasswordResetAdmin.is_expired": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 3,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [275, 276, 277],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 6, 7, 8, 11, 12, 13, 15, 26, 33, 34, 35, 37, 39, 64, 66, 67,
+            80, 81, 92, 93, 94, 96, 107, 112, 113, 114, 115, 117, 140, 152, 154,
+            160, 162, 168, 169, 171, 177, 178, 180, 182, 183, 198, 199, 209,
+            210, 211, 213, 224, 229, 230, 231, 232, 234, 246, 248, 254, 256,
+            262, 264, 270, 271, 273, 279, 280, 284, 285, 286
+          ],
+          "summary": {
+            "covered_lines": 65,
+            "num_statements": 65,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "UserAdmin": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 13,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 13,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [69, 71, 72, 73, 74, 75, 76, 77, 78, 83, 84, 85, 86],
+          "excluded_lines": []
+        },
+        "EmailVerificationAdmin": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 25,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 25,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [
+            142, 143, 144, 150, 156, 157, 158, 164, 165, 166, 173, 174, 175,
+            185, 187, 188, 189, 190, 195, 196, 201, 203, 204, 205, 206
+          ],
+          "excluded_lines": []
+        },
+        "PasswordResetAdmin": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 16,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 16,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [
+            236, 237, 238, 244, 250, 251, 252, 258, 259, 260, 266, 267, 268,
+            275, 276, 277
+          ],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 6, 7, 8, 11, 12, 13, 15, 26, 33, 34, 35, 37, 39, 64, 66, 67,
+            80, 81, 92, 93, 94, 96, 107, 112, 113, 114, 115, 117, 140, 152, 154,
+            160, 162, 168, 169, 171, 177, 178, 180, 182, 183, 198, 199, 209,
+            210, 211, 213, 224, 229, 230, 231, 232, 234, 246, 248, 254, 256,
+            262, 264, 270, 271, 273, 279, 280, 284, 285, 286
+          ],
+          "summary": {
+            "covered_lines": 65,
+            "num_statements": 65,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\models.py": {
+    "apps/users/models.py": {
       "executed_lines": [
         3, 5, 6, 9, 10, 14, 15, 18, 25, 30, 39, 44, 52, 59, 67, 68, 69, 70, 71,
-        74, 78, 80, 82, 91, 92, 94, 95, 102, 107, 113, 117, 123, 129, 130, 131,
-        132, 133, 137, 139, 143, 149, 154, 155, 157, 158, 165, 171, 175, 181,
-        187, 188, 189, 190, 191, 195, 197, 201, 207
+        74, 78, 82, 84, 85, 86, 88, 91, 92, 94, 95, 102, 107, 113, 117, 123,
+        129, 130, 131, 132, 133, 137, 139, 143, 145, 147, 149, 151, 154, 155,
+        157, 158, 165, 171, 175, 181, 187, 188, 189, 190, 191, 195, 197, 201,
+        203, 205, 207, 209
       ],
       "summary": {
-        "covered_lines": 55,
-        "num_statements": 67,
-        "percent_covered": 82.08955223880596,
-        "percent_covered_display": "82.09",
-        "missing_lines": 12,
-        "excluded_lines": 0
+        "covered_lines": 63,
+        "num_statements": 66,
+        "percent_covered": 95.45454545454545,
+        "percent_covered_display": "95.45",
+        "missing_lines": 3,
+        "excluded_lines": 0,
+        "percent_statements_covered": 95.45454545454545,
+        "percent_statements_covered_display": "95.45"
       },
-      "missing_lines": [84, 85, 86, 88, 141, 145, 147, 151, 199, 203, 205, 209],
-      "excluded_lines": []
+      "missing_lines": [80, 141, 199],
+      "excluded_lines": [],
+      "functions": {
+        "User.__str__": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [80],
+          "excluded_lines": []
+        },
+        "User.is_locked": {
+          "executed_lines": [84, 85, 86, 88],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "EmailVerification.__str__": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [141],
+          "excluded_lines": []
+        },
+        "EmailVerification.is_expired": {
+          "executed_lines": [145, 147],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 2,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "EmailVerification.is_verified": {
+          "executed_lines": [151],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 1,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PasswordReset.__str__": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [199],
+          "excluded_lines": []
+        },
+        "PasswordReset.is_expired": {
+          "executed_lines": [203, 205],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 2,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PasswordReset.is_used": {
+          "executed_lines": [209],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 1,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 6, 9, 10, 14, 15, 18, 25, 30, 39, 44, 52, 59, 67, 68, 69, 70,
+            71, 74, 78, 82, 91, 92, 94, 95, 102, 107, 113, 117, 123, 129, 130,
+            131, 132, 133, 137, 139, 143, 149, 154, 155, 157, 158, 165, 171,
+            175, 181, 187, 188, 189, 190, 191, 195, 197, 201, 207
+          ],
+          "summary": {
+            "covered_lines": 53,
+            "num_statements": 53,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "User": {
+          "executed_lines": [84, 85, 86, 88],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 5,
+            "percent_covered": 80.0,
+            "percent_covered_display": "80.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 80.0,
+            "percent_statements_covered_display": "80.00"
+          },
+          "missing_lines": [80],
+          "excluded_lines": []
+        },
+        "User.Meta": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "EmailVerification": {
+          "executed_lines": [145, 147, 151],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 4,
+            "percent_covered": 75.0,
+            "percent_covered_display": "75.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 75.0,
+            "percent_statements_covered_display": "75.00"
+          },
+          "missing_lines": [141],
+          "excluded_lines": []
+        },
+        "EmailVerification.Meta": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PasswordReset": {
+          "executed_lines": [203, 205, 209],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 4,
+            "percent_covered": 75.0,
+            "percent_covered_display": "75.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 75.0,
+            "percent_statements_covered_display": "75.00"
+          },
+          "missing_lines": [199],
+          "excluded_lines": []
+        },
+        "PasswordReset.Meta": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 6, 9, 10, 14, 15, 18, 25, 30, 39, 44, 52, 59, 67, 68, 69, 70,
+            71, 74, 78, 82, 91, 92, 94, 95, 102, 107, 113, 117, 123, 129, 130,
+            131, 132, 133, 137, 139, 143, 149, 154, 155, 157, 158, 165, 171,
+            175, 181, 187, 188, 189, 190, 191, 195, 197, 201, 207
+          ],
+          "summary": {
+            "covered_lines": 53,
+            "num_statements": 53,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\serializers.py": {
+    "apps/users/serializers.py": {
       "executed_lines": [
-        3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 19, 20, 26, 31, 32, 34, 42, 65, 87,
-        114, 115, 117, 120, 125, 126, 128, 164, 165, 167, 170, 175, 176, 178,
-        181, 182, 185, 186, 191, 192, 195, 197, 199, 200, 201, 204, 206, 207,
-        208, 211, 212, 213, 216, 217, 219, 221, 227, 228, 230, 231, 232, 234,
-        249, 250, 252, 253, 259, 265, 283
+        3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 19, 20, 26, 31, 32, 34, 36, 37, 40,
+        42, 45, 49, 50, 52, 53, 58, 59, 63, 65, 68, 69, 71, 72, 77, 78, 80, 81,
+        85, 87, 89, 90, 94, 97, 98, 99, 104, 111, 114, 115, 117, 120, 125, 126,
+        128, 131, 132, 134, 135, 140, 141, 144, 146, 147, 152, 153, 156, 157,
+        161, 164, 165, 167, 170, 175, 176, 180, 183, 184, 188, 196, 197, 200,
+        202, 209, 216, 217, 218, 221, 222, 224, 226, 229, 232, 233, 235, 236,
+        237, 239, 241, 243, 244, 246, 247, 251, 254, 255, 257, 258, 264, 270,
+        272, 278, 279, 281, 286, 288, 290, 291, 293, 294, 298, 304, 305, 307,
+        308, 309, 312, 313, 315, 316, 317, 320, 321, 323, 324, 325, 326, 329,
+        330, 332, 333, 334, 337, 338, 340, 341, 346, 347, 349, 352, 353, 355,
+        356, 359, 360, 362, 365, 366, 368, 371, 372, 374
       ],
       "summary": {
-        "covered_lines": 62,
-        "num_statements": 128,
-        "percent_covered": 48.4375,
-        "percent_covered_display": "48.44",
-        "missing_lines": 66,
-        "excluded_lines": 0
+        "covered_lines": 144,
+        "num_statements": 158,
+        "percent_covered": 91.13924050632912,
+        "percent_covered_display": "91.14",
+        "missing_lines": 14,
+        "excluded_lines": 0,
+        "percent_statements_covered": 91.13924050632912,
+        "percent_statements_covered_display": "91.14"
       },
       "missing_lines": [
-        36, 37, 40, 45, 46, 49, 50, 52, 53, 58, 59, 60, 61, 63, 68, 69, 71, 72,
-        77, 78, 80, 81, 85, 89, 90, 94, 97, 98, 99, 100, 101, 104, 111, 131,
-        132, 134, 135, 140, 141, 144, 146, 147, 152, 153, 156, 157, 161, 224,
-        236, 238, 239, 241, 242, 246, 267, 268, 273, 274, 276, 277, 281, 285,
-        286, 288, 289, 293
+        46, 60, 61, 100, 101, 191, 204, 205, 206, 211, 212, 213, 273, 282
       ],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "UserRegisterSerializer.validate_email": {
+          "executed_lines": [36, 37, 40],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 3,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "UserRegisterSerializer.validate_password": {
+          "executed_lines": [45, 49, 50, 52, 53, 58, 59, 63],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 11,
+            "percent_covered": 72.72727272727273,
+            "percent_covered_display": "72.73",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 72.72727272727273,
+            "percent_statements_covered_display": "72.73"
+          },
+          "missing_lines": [46, 60, 61],
+          "excluded_lines": []
+        },
+        "UserRegisterSerializer.validate": {
+          "executed_lines": [68, 69, 71, 72, 77, 78, 80, 81, 85],
+          "summary": {
+            "covered_lines": 9,
+            "num_statements": 9,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "UserRegisterSerializer.create": {
+          "executed_lines": [89, 90, 94, 97, 98, 99, 104, 111],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 10,
+            "percent_covered": 80.0,
+            "percent_covered_display": "80.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 80.0,
+            "percent_statements_covered_display": "80.00"
+          },
+          "missing_lines": [100, 101],
+          "excluded_lines": []
+        },
+        "UserLoginSerializer.validate": {
+          "executed_lines": [
+            131, 132, 134, 135, 140, 141, 144, 146, 147, 152, 153, 156, 157, 161
+          ],
+          "summary": {
+            "covered_lines": 14,
+            "num_statements": 14,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PreviewLoginSerializer.validate": {
+          "executed_lines": [
+            183, 184, 188, 196, 197, 200, 202, 209, 216, 217, 218
+          ],
+          "summary": {
+            "covered_lines": 11,
+            "num_statements": 18,
+            "percent_covered": 61.111111111111114,
+            "percent_covered_display": "61.11",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 61.111111111111114,
+            "percent_statements_covered_display": "61.11"
+          },
+          "missing_lines": [191, 204, 205, 206, 211, 212, 213],
+          "excluded_lines": []
+        },
+        "SendEmailVerificationSerializer.validate_email": {
+          "executed_lines": [229],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 1,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "SendPasswordResetSerializer.validate": {
+          "executed_lines": [241, 243, 244, 246, 247, 251],
+          "summary": {
+            "covered_lines": 6,
+            "num_statements": 6,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PasswordResetSerializer.validate_password": {
+          "executed_lines": [272, 278, 279, 281, 286],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 7,
+            "percent_covered": 71.42857142857143,
+            "percent_covered_display": "71.43",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 71.42857142857143,
+            "percent_statements_covered_display": "71.43"
+          },
+          "missing_lines": [273, 282],
+          "excluded_lines": []
+        },
+        "PasswordResetSerializer.validate": {
+          "executed_lines": [290, 291, 293, 294, 298],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 5,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 19, 20, 26, 31, 32, 34, 42, 65,
+            87, 114, 115, 117, 120, 125, 126, 128, 164, 165, 167, 170, 175, 176,
+            180, 221, 222, 224, 226, 232, 233, 235, 236, 237, 239, 254, 255,
+            257, 258, 264, 270, 288, 304, 305, 307, 308, 309, 312, 313, 315,
+            316, 317, 320, 321, 323, 324, 325, 326, 329, 330, 332, 333, 334,
+            337, 338, 340, 341, 346, 347, 349, 352, 353, 355, 356, 359, 360,
+            362, 365, 366, 368, 371, 372, 374
+          ],
+          "summary": {
+            "covered_lines": 74,
+            "num_statements": 74,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "UserRegisterSerializer": {
+          "executed_lines": [
+            36, 37, 40, 45, 49, 50, 52, 53, 58, 59, 63, 68, 69, 71, 72, 77, 78,
+            80, 81, 85, 89, 90, 94, 97, 98, 99, 104, 111
+          ],
+          "summary": {
+            "covered_lines": 28,
+            "num_statements": 33,
+            "percent_covered": 84.84848484848484,
+            "percent_covered_display": "84.85",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 84.84848484848484,
+            "percent_statements_covered_display": "84.85"
+          },
+          "missing_lines": [46, 60, 61, 100, 101],
+          "excluded_lines": []
+        },
+        "UserLoginSerializer": {
+          "executed_lines": [
+            131, 132, 134, 135, 140, 141, 144, 146, 147, 152, 153, 156, 157, 161
+          ],
+          "summary": {
+            "covered_lines": 14,
+            "num_statements": 14,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PreviewLoginSerializer": {
+          "executed_lines": [
+            183, 184, 188, 196, 197, 200, 202, 209, 216, 217, 218
+          ],
+          "summary": {
+            "covered_lines": 11,
+            "num_statements": 18,
+            "percent_covered": 61.111111111111114,
+            "percent_covered_display": "61.11",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 61.111111111111114,
+            "percent_statements_covered_display": "61.11"
+          },
+          "missing_lines": [191, 204, 205, 206, 211, 212, 213],
+          "excluded_lines": []
+        },
+        "SendEmailVerificationSerializer": {
+          "executed_lines": [229],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 1,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "SendPasswordResetSerializer": {
+          "executed_lines": [241, 243, 244, 246, 247, 251],
+          "summary": {
+            "covered_lines": 6,
+            "num_statements": 6,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PasswordResetSerializer": {
+          "executed_lines": [272, 278, 279, 281, 286, 290, 291, 293, 294, 298],
+          "summary": {
+            "covered_lines": 10,
+            "num_statements": 12,
+            "percent_covered": 83.33333333333333,
+            "percent_covered_display": "83.33",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 83.33333333333333,
+            "percent_statements_covered_display": "83.33"
+          },
+          "missing_lines": [273, 282],
+          "excluded_lines": []
+        },
+        "UserInfoSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "RegisterResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "LoginResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "PreviewResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "MessageResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "ErrorResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "TokenRefreshRequestSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "TokenRefreshResponseSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaRefreshRequestSerializer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 0,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 7, 8, 9, 10, 11, 13, 16, 17, 19, 20, 26, 31, 32, 34, 42, 65,
+            87, 114, 115, 117, 120, 125, 126, 128, 164, 165, 167, 170, 175, 176,
+            180, 221, 222, 224, 226, 232, 233, 235, 236, 237, 239, 254, 255,
+            257, 258, 264, 270, 288, 304, 305, 307, 308, 309, 312, 313, 315,
+            316, 317, 320, 321, 323, 324, 325, 326, 329, 330, 332, 333, 334,
+            337, 338, 340, 341, 346, 347, 349, 352, 353, 355, 356, 359, 360,
+            362, 365, 366, 368, 371, 372, 374
+          ],
+          "summary": {
+            "covered_lines": 74,
+            "num_statements": 74,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\tasks.py": {
-      "executed_lines": [3, 5, 7, 8, 9, 10, 12, 15, 26, 110, 121],
+    "apps/users/tasks.py": {
+      "executed_lines": [
+        3, 5, 7, 8, 9, 10, 12, 15, 26, 38, 41, 42, 45, 48, 54, 60, 63, 69, 72,
+        75, 110, 121, 133, 136, 137, 140, 143, 149, 155, 158, 164, 167, 170
+      ],
+      "summary": {
+        "covered_lines": 32,
+        "num_statements": 46,
+        "percent_covered": 69.56521739130434,
+        "percent_covered_display": "69.57",
+        "missing_lines": 14,
+        "excluded_lines": 0,
+        "percent_statements_covered": 69.56521739130434,
+        "percent_statements_covered_display": "69.57"
+      },
+      "missing_lines": [
+        80, 82, 90, 97, 98, 101, 107, 175, 177, 185, 192, 193, 196, 202
+      ],
+      "excluded_lines": [],
+      "functions": {
+        "send_email_verification": {
+          "executed_lines": [38, 41, 42, 45, 48, 54, 60, 63, 69, 72, 75],
+          "summary": {
+            "covered_lines": 11,
+            "num_statements": 18,
+            "percent_covered": 61.111111111111114,
+            "percent_covered_display": "61.11",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 61.111111111111114,
+            "percent_statements_covered_display": "61.11"
+          },
+          "missing_lines": [80, 82, 90, 97, 98, 101, 107],
+          "excluded_lines": []
+        },
+        "send_password_reset_email": {
+          "executed_lines": [
+            133, 136, 137, 140, 143, 149, 155, 158, 164, 167, 170
+          ],
+          "summary": {
+            "covered_lines": 11,
+            "num_statements": 18,
+            "percent_covered": 61.111111111111114,
+            "percent_covered_display": "61.11",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 61.111111111111114,
+            "percent_statements_covered_display": "61.11"
+          },
+          "missing_lines": [175, 177, 185, 192, 193, 196, 202],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [3, 5, 7, 8, 9, 10, 12, 15, 26, 110, 121],
+          "summary": {
+            "covered_lines": 10,
+            "num_statements": 10,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [
+            3, 5, 7, 8, 9, 10, 12, 15, 26, 38, 41, 42, 45, 48, 54, 60, 63, 69,
+            72, 75, 110, 121, 133, 136, 137, 140, 143, 149, 155, 158, 164, 167,
+            170
+          ],
+          "summary": {
+            "covered_lines": 32,
+            "num_statements": 46,
+            "percent_covered": 69.56521739130434,
+            "percent_covered_display": "69.57",
+            "missing_lines": 14,
+            "excluded_lines": 0,
+            "percent_statements_covered": 69.56521739130434,
+            "percent_statements_covered_display": "69.57"
+          },
+          "missing_lines": [
+            80, 82, 90, 97, 98, 101, 107, 175, 177, 185, 192, 193, 196, 202
+          ],
+          "excluded_lines": []
+        }
+      }
+    },
+    "apps/users/throttling.py": {
+      "executed_lines": [3, 5, 8, 9, 16, 17, 19, 27, 31, 33, 44, 49, 51],
       "summary": {
         "covered_lines": 11,
-        "num_statements": 47,
-        "percent_covered": 23.404255319148938,
-        "percent_covered_display": "23.40",
-        "missing_lines": 36,
-        "excluded_lines": 0
+        "num_statements": 13,
+        "percent_covered": 84.61538461538461,
+        "percent_covered_display": "84.62",
+        "missing_lines": 2,
+        "excluded_lines": 0,
+        "percent_statements_covered": 84.61538461538461,
+        "percent_statements_covered_display": "84.62"
       },
-      "missing_lines": [
-        38, 41, 42, 45, 48, 54, 60, 63, 69, 72, 75, 80, 82, 90, 97, 98, 101,
-        107, 133, 136, 137, 140, 143, 149, 155, 158, 164, 167, 170, 175, 177,
-        185, 192, 193, 196, 202
-      ],
-      "excluded_lines": []
-    },
-    "apps\\users\\throttling.py": {
-      "executed_lines": [3, 5, 8, 9, 14, 15, 17, 28, 33, 35],
-      "summary": {
-        "covered_lines": 9,
-        "num_statements": 10,
-        "percent_covered": 90.0,
-        "percent_covered_display": "90.00",
-        "missing_lines": 1,
-        "excluded_lines": 0
+      "missing_lines": [28, 46],
+      "excluded_lines": [],
+      "functions": {
+        "PreviewLoginThrottle.allow_request": {
+          "executed_lines": [27, 31],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 3,
+            "percent_covered": 66.66666666666667,
+            "percent_covered_display": "66.67",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 66.66666666666667,
+            "percent_statements_covered_display": "66.67"
+          },
+          "missing_lines": [28],
+          "excluded_lines": []
+        },
+        "PreviewLoginThrottle.get_cache_key": {
+          "executed_lines": [44, 49, 51],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 4,
+            "percent_covered": 75.0,
+            "percent_covered_display": "75.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 75.0,
+            "percent_statements_covered_display": "75.00"
+          },
+          "missing_lines": [46],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [3, 5, 8, 9, 16, 17, 19, 33],
+          "summary": {
+            "covered_lines": 6,
+            "num_statements": 6,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
       },
-      "missing_lines": [30],
-      "excluded_lines": []
+      "classes": {
+        "PreviewLoginThrottle": {
+          "executed_lines": [27, 31, 44, 49, 51],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 7,
+            "percent_covered": 71.42857142857143,
+            "percent_covered_display": "71.43",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 71.42857142857143,
+            "percent_statements_covered_display": "71.43"
+          },
+          "missing_lines": [28, 46],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [3, 5, 8, 9, 16, 17, 19, 33],
+          "summary": {
+            "covered_lines": 6,
+            "num_statements": 6,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\urls.py": {
+    "apps/users/urls.py": {
       "executed_lines": [3, 5, 20, 22, 24],
       "summary": {
-        "covered_lines": 5,
-        "num_statements": 5,
+        "covered_lines": 4,
+        "num_statements": 4,
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [3, 5, 20, 22, 24],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [3, 5, 20, 22, 24],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\utils.py": {
+    "apps/users/utils.py": {
       "executed_lines": [
         3, 5, 6, 7, 8, 9, 11, 12, 15, 27, 28, 31, 32, 33, 36, 38, 41, 42, 44,
-        50, 51, 52, 55, 61, 62, 63, 69, 72, 73, 74, 75, 76, 77, 82, 85, 86, 87,
-        88, 93, 96, 97, 98, 99, 100, 103, 105, 108, 120, 121, 122, 125, 139,
-        150, 151, 153, 157, 158, 160, 162, 163, 166, 168, 169, 170, 172, 173,
-        176, 186, 188, 190, 192, 193, 194, 195, 198, 199
+        45, 47, 50, 51, 52, 55, 61, 62, 63, 69, 72, 73, 74, 75, 76, 77, 82, 85,
+        86, 87, 88, 93, 96, 97, 98, 99, 100, 103, 105, 108, 120, 121, 122, 125,
+        139, 156, 158, 160, 162, 171, 172, 173, 177, 178, 180, 182, 186, 189,
+        190, 191, 193, 194, 195, 199, 201, 206, 209, 219, 221, 223, 225, 226,
+        227, 228, 231, 232
       ],
       "summary": {
-        "covered_lines": 76,
-        "num_statements": 84,
-        "percent_covered": 90.47619047619048,
-        "percent_covered_display": "90.48",
+        "covered_lines": 84,
+        "num_statements": 92,
+        "percent_covered": 91.30434782608695,
+        "percent_covered_display": "91.30",
         "missing_lines": 8,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 91.30434782608695,
+        "percent_statements_covered_display": "91.30"
       },
-      "missing_lines": [45, 47, 135, 136, 154, 155, 200, 201],
-      "excluded_lines": []
+      "missing_lines": [135, 136, 163, 167, 174, 175, 233, 234],
+      "excluded_lines": [],
+      "functions": {
+        "generate_captcha": {
+          "executed_lines": [
+            27, 28, 31, 32, 33, 36, 38, 41, 42, 44, 45, 47, 50, 51, 52, 55, 61,
+            62, 63, 69, 72, 73, 74, 75, 76, 77, 82, 85, 86, 87, 88, 93, 96, 97,
+            98, 99, 100, 103, 105
+          ],
+          "summary": {
+            "covered_lines": 39,
+            "num_statements": 39,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "store_captcha": {
+          "executed_lines": [120, 121, 122],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 3,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "get_captcha_answer": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 2,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [135, 136],
+          "excluded_lines": []
+        },
+        "verify_captcha": {
+          "executed_lines": [
+            156, 158, 160, 162, 171, 172, 173, 177, 178, 180, 182, 186, 189,
+            190, 191, 193, 194, 195, 199, 201, 206
+          ],
+          "summary": {
+            "covered_lines": 21,
+            "num_statements": 25,
+            "percent_covered": 84.0,
+            "percent_covered_display": "84.00",
+            "missing_lines": 4,
+            "excluded_lines": 0,
+            "percent_statements_covered": 84.0,
+            "percent_statements_covered_display": "84.00"
+          },
+          "missing_lines": [163, 167, 174, 175],
+          "excluded_lines": []
+        },
+        "find_user_by_email_or_username": {
+          "executed_lines": [219, 221, 223, 225, 226, 227, 228, 231, 232],
+          "summary": {
+            "covered_lines": 9,
+            "num_statements": 11,
+            "percent_covered": 81.81818181818181,
+            "percent_covered_display": "81.82",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 81.81818181818181,
+            "percent_statements_covered_display": "81.82"
+          },
+          "missing_lines": [233, 234],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [3, 5, 6, 7, 8, 9, 11, 12, 15, 108, 125, 139, 209],
+          "summary": {
+            "covered_lines": 12,
+            "num_statements": 12,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [
+            3, 5, 6, 7, 8, 9, 11, 12, 15, 27, 28, 31, 32, 33, 36, 38, 41, 42,
+            44, 45, 47, 50, 51, 52, 55, 61, 62, 63, 69, 72, 73, 74, 75, 76, 77,
+            82, 85, 86, 87, 88, 93, 96, 97, 98, 99, 100, 103, 105, 108, 120,
+            121, 122, 125, 139, 156, 158, 160, 162, 171, 172, 173, 177, 178,
+            180, 182, 186, 189, 190, 191, 193, 194, 195, 199, 201, 206, 209,
+            219, 221, 223, 225, 226, 227, 228, 231, 232
+          ],
+          "summary": {
+            "covered_lines": 84,
+            "num_statements": 92,
+            "percent_covered": 91.30434782608695,
+            "percent_covered_display": "91.30",
+            "missing_lines": 8,
+            "excluded_lines": 0,
+            "percent_statements_covered": 91.30434782608695,
+            "percent_statements_covered_display": "91.30"
+          },
+          "missing_lines": [135, 136, 163, 167, 174, 175, 233, 234],
+          "excluded_lines": []
+        }
+      }
     },
-    "apps\\users\\views.py": {
+    "apps/users/views.py": {
       "executed_lines": [
-        3, 5, 6, 8, 9, 17, 18, 19, 24, 25, 26, 27, 28, 29, 30, 31, 32, 34, 37,
-        40, 41, 43, 45, 55, 56, 57, 60, 64, 66, 89, 103, 104, 106, 116, 117,
-        119, 140, 141, 143, 171, 172, 174, 176, 248, 317, 318, 320, 322, 456,
-        457, 459, 460, 462, 472, 474, 477, 479, 489, 491, 498, 505, 520, 522,
-        524, 527, 528, 529, 532, 535, 536, 537, 539, 541, 547, 549, 555, 556,
-        558, 560, 601, 602, 604, 606, 650, 651, 653, 655, 733, 734, 736, 738,
-        803, 804, 806, 808, 883, 884, 886, 888, 980, 981, 983, 985
+        3, 5, 6, 8, 9, 26, 27, 28, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 44,
+        47, 50, 51, 53, 55, 65, 66, 67, 70, 74, 76, 84, 87, 90, 99, 109, 110,
+        113, 114, 116, 124, 131, 134, 135, 137, 146, 159, 160, 162, 164, 165,
+        166, 170, 173, 176, 177, 179, 203, 204, 206, 208, 218, 234, 236, 238,
+        239, 240, 243, 246, 249, 251, 252, 255, 263, 270, 273, 287, 298, 299,
+        300, 303, 309, 310, 311, 318, 319, 322, 323, 324, 325, 332, 341, 342,
+        345, 359, 362, 363, 365, 367, 378, 393, 395, 397, 400, 401, 402, 405,
+        406, 407, 408, 411, 418, 421, 423, 424, 425, 427, 429, 431, 432, 435,
+        442, 450, 457, 470, 473, 476, 477, 482, 483, 484, 485, 488, 489, 495,
+        501, 504, 518, 519, 521, 522, 524, 534, 536, 541, 551, 560, 567, 577,
+        578, 580, 593, 594, 595, 597, 605, 607, 613, 614, 616, 618, 628, 638,
+        640, 641, 646, 648, 649, 652, 657, 658, 669, 670, 672, 674, 683, 694,
+        700, 702, 704, 714, 727, 728, 730, 732, 743, 758, 759, 760, 766, 769,
+        776, 779, 782, 793, 799, 821, 822, 824, 826, 836, 846, 848, 849, 850,
+        851, 857, 858, 864, 865, 874, 875, 876, 877, 880, 881, 883, 904, 905,
+        907, 909, 919, 995, 996, 998, 1000, 1011, 1025, 1026, 1027, 1029, 1030,
+        1031, 1034, 1035, 1042, 1051, 1054, 1057, 1059, 1062, 1065, 1075, 1082,
+        1103, 1104, 1106, 1108, 1119, 1133, 1134, 1135, 1137, 1140, 1141, 1142,
+        1144, 1145, 1166, 1173, 1189, 1198, 1199, 1202, 1203, 1204, 1205, 1211,
+        1212, 1218, 1219, 1225, 1226, 1227, 1230, 1231, 1233
       ],
       "summary": {
-        "covered_lines": 89,
-        "num_statements": 341,
-        "percent_covered": 26.099706744868037,
-        "percent_covered_display": "26.10",
-        "missing_lines": 252,
-        "excluded_lines": 0
+        "covered_lines": 261,
+        "num_statements": 357,
+        "percent_covered": 73.10924369747899,
+        "percent_covered_display": "73.11",
+        "missing_lines": 96,
+        "excluded_lines": 0,
+        "percent_statements_covered": 73.10924369747899,
+        "percent_statements_covered_display": "73.11"
       },
       "missing_lines": [
-        74, 77, 80, 99, 100, 113, 132, 133, 134, 137, 154, 155, 160, 162, 163,
-        164, 168, 187, 188, 189, 192, 198, 199, 200, 203, 207, 208, 211, 212,
-        213, 214, 221, 228, 229, 232, 233, 236, 239, 243, 244, 246, 264, 266,
-        268, 269, 270, 273, 276, 279, 280, 281, 284, 292, 299, 302, 337, 339,
-        341, 344, 345, 346, 349, 350, 351, 352, 355, 356, 357, 358, 359, 362,
-        365, 367, 368, 369, 371, 373, 375, 376, 379, 386, 391, 398, 404, 405,
-        408, 411, 414, 415, 420, 421, 422, 423, 426, 427, 433, 434, 435, 436,
-        439, 442, 570, 572, 573, 578, 580, 581, 584, 589, 590, 594, 595, 617,
-        618, 623, 625, 627, 628, 630, 631, 632, 634, 637, 642, 644, 670, 671,
-        672, 673, 678, 681, 682, 688, 691, 694, 705, 711, 716, 718, 720, 721,
-        727, 748, 750, 751, 752, 753, 759, 760, 766, 767, 773, 774, 775, 776,
-        779, 780, 782, 787, 789, 791, 792, 797, 818, 820, 821, 822, 828, 829,
-        830, 831, 837, 838, 844, 847, 850, 851, 852, 853, 856, 862, 867, 869,
-        871, 872, 877, 902, 903, 904, 906, 907, 908, 911, 912, 913, 919, 928,
-        931, 934, 936, 939, 942, 952, 959, 964, 966, 968, 969, 974, 999, 1000,
-        1001, 1003, 1006, 1007, 1008, 1010, 1011, 1012, 1016, 1020, 1021, 1022,
-        1023, 1029, 1030, 1036, 1037, 1040, 1043, 1049, 1058, 1059, 1062, 1063,
-        1064, 1065, 1071, 1072, 1078, 1079, 1085, 1086, 1087, 1090, 1091, 1093,
-        1098, 1100, 1102, 1103, 1108
+        190, 191, 194, 196, 197, 198, 200, 314, 346, 349, 352, 356, 357, 412,
+        413, 414, 415, 466, 467, 496, 497, 498, 539, 553, 582, 585, 586, 587,
+        590, 599, 662, 663, 695, 705, 707, 708, 709, 711, 719, 721, 761, 770,
+        804, 806, 808, 809, 815, 888, 890, 892, 893, 898, 929, 931, 932, 933,
+        939, 940, 941, 942, 948, 949, 955, 958, 961, 962, 963, 964, 967, 973,
+        978, 980, 982, 983, 989, 1036, 1087, 1089, 1091, 1092, 1097, 1146, 1153,
+        1157, 1158, 1159, 1160, 1167, 1174, 1177, 1180, 1238, 1240, 1242, 1243,
+        1248
       ],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "BaseCaptchaView._handle_captcha_error": {
+          "executed_lines": [65, 66, 67, 70, 74],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 5,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "BaseCaptchaView._create_captcha_response": {
+          "executed_lines": [84, 87, 90],
+          "summary": {
+            "covered_lines": 3,
+            "num_statements": 3,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "BaseCaptchaView._generate_tokens": {
+          "executed_lines": [109, 110],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 2,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaAPIView.get": {
+          "executed_lines": [131],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 1,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaRefreshAPIView.post": {
+          "executed_lines": [159, 160, 162, 164, 165, 166, 170, 173],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 8,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaAnswerAPIView.get": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 7,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [190, 191, 194, 196, 197, 198, 200],
+          "excluded_lines": []
+        },
+        "RegisterAPIView.post": {
+          "executed_lines": [
+            234, 236, 238, 239, 240, 243, 246, 249, 251, 252, 255, 263, 270, 273
+          ],
+          "summary": {
+            "covered_lines": 14,
+            "num_statements": 14,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "RegisterAPIView._format_error_response": {
+          "executed_lines": [
+            298, 299, 300, 303, 309, 310, 311, 318, 319, 322, 323, 324, 325,
+            332, 341, 342, 345, 359
+          ],
+          "summary": {
+            "covered_lines": 18,
+            "num_statements": 24,
+            "percent_covered": 75.0,
+            "percent_covered_display": "75.00",
+            "missing_lines": 6,
+            "excluded_lines": 0,
+            "percent_statements_covered": 75.0,
+            "percent_statements_covered_display": "75.00"
+          },
+          "missing_lines": [314, 346, 349, 352, 356, 357],
+          "excluded_lines": []
+        },
+        "LoginAPIView.post": {
+          "executed_lines": [
+            393, 395, 397, 400, 401, 402, 405, 406, 407, 408, 411, 418, 421,
+            423, 424, 425, 427, 429, 431, 432, 435, 442, 450, 457, 470, 473,
+            476, 477, 482, 483, 484, 485, 488, 489, 495, 501, 504
+          ],
+          "summary": {
+            "covered_lines": 37,
+            "num_statements": 46,
+            "percent_covered": 80.43478260869566,
+            "percent_covered_display": "80.43",
+            "missing_lines": 9,
+            "excluded_lines": 0,
+            "percent_statements_covered": 80.43478260869566,
+            "percent_statements_covered_display": "80.43"
+          },
+          "missing_lines": [412, 413, 414, 415, 466, 467, 496, 497, 498],
+          "excluded_lines": []
+        },
+        "PreviewAPIView._get_avatar_letter": {
+          "executed_lines": [534, 536],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 3,
+            "percent_covered": 66.66666666666667,
+            "percent_covered_display": "66.67",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 66.66666666666667,
+            "percent_statements_covered_display": "66.67"
+          },
+          "missing_lines": [539],
+          "excluded_lines": []
+        },
+        "PreviewAPIView._format_user_preview_data": {
+          "executed_lines": [551, 560],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 3,
+            "percent_covered": 66.66666666666667,
+            "percent_covered_display": "66.67",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 66.66666666666667,
+            "percent_statements_covered_display": "66.67"
+          },
+          "missing_lines": [553],
+          "excluded_lines": []
+        },
+        "PreviewAPIView.post": {
+          "executed_lines": [578, 580, 593, 594, 595, 597, 605, 607],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 14,
+            "percent_covered": 57.142857142857146,
+            "percent_covered_display": "57.14",
+            "missing_lines": 6,
+            "excluded_lines": 0,
+            "percent_statements_covered": 57.142857142857146,
+            "percent_statements_covered_display": "57.14"
+          },
+          "missing_lines": [582, 585, 586, 587, 590, 599],
+          "excluded_lines": []
+        },
+        "TokenRefreshAPIView.post": {
+          "executed_lines": [638, 640, 641, 646, 648, 649, 652, 657, 658],
+          "summary": {
+            "covered_lines": 9,
+            "num_statements": 11,
+            "percent_covered": 81.81818181818181,
+            "percent_covered_display": "81.82",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 81.81818181818181,
+            "percent_statements_covered_display": "81.82"
+          },
+          "missing_lines": [662, 663],
+          "excluded_lines": []
+        },
+        "LogoutAPIView.post": {
+          "executed_lines": [694, 700, 702, 704, 714],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 13,
+            "percent_covered": 38.46153846153846,
+            "percent_covered_display": "38.46",
+            "missing_lines": 8,
+            "excluded_lines": 0,
+            "percent_statements_covered": 38.46153846153846,
+            "percent_statements_covered_display": "38.46"
+          },
+          "missing_lines": [695, 705, 707, 708, 709, 711, 719, 721],
+          "excluded_lines": []
+        },
+        "SendEmailVerificationAPIView.post": {
+          "executed_lines": [758, 759, 760, 766, 769, 776, 779, 782, 793, 799],
+          "summary": {
+            "covered_lines": 10,
+            "num_statements": 17,
+            "percent_covered": 58.8235294117647,
+            "percent_covered_display": "58.82",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 58.8235294117647,
+            "percent_statements_covered_display": "58.82"
+          },
+          "missing_lines": [761, 770, 804, 806, 808, 809, 815],
+          "excluded_lines": []
+        },
+        "VerifyEmailAPIView.get": {
+          "executed_lines": [
+            846, 848, 849, 850, 851, 857, 858, 864, 865, 874, 875, 876, 877,
+            880, 881, 883
+          ],
+          "summary": {
+            "covered_lines": 16,
+            "num_statements": 21,
+            "percent_covered": 76.19047619047619,
+            "percent_covered_display": "76.19",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 76.19047619047619,
+            "percent_statements_covered_display": "76.19"
+          },
+          "missing_lines": [888, 890, 892, 893, 898],
+          "excluded_lines": []
+        },
+        "ResendEmailVerificationAPIView.post": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 23,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 23,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [
+            929, 931, 932, 933, 939, 940, 941, 942, 948, 949, 955, 958, 961,
+            962, 963, 964, 967, 973, 978, 980, 982, 983, 989
+          ],
+          "excluded_lines": []
+        },
+        "SendPasswordResetAPIView.post": {
+          "executed_lines": [
+            1025, 1026, 1027, 1029, 1030, 1031, 1034, 1035, 1042, 1051, 1054,
+            1057, 1059, 1062, 1065, 1075, 1082
+          ],
+          "summary": {
+            "covered_lines": 17,
+            "num_statements": 23,
+            "percent_covered": 73.91304347826087,
+            "percent_covered_display": "73.91",
+            "missing_lines": 6,
+            "excluded_lines": 0,
+            "percent_statements_covered": 73.91304347826087,
+            "percent_statements_covered_display": "73.91"
+          },
+          "missing_lines": [1036, 1087, 1089, 1091, 1092, 1097],
+          "excluded_lines": []
+        },
+        "PasswordResetAPIView.post": {
+          "executed_lines": [
+            1133, 1134, 1135, 1137, 1140, 1141, 1142, 1144, 1145, 1166, 1173,
+            1189, 1198, 1199, 1202, 1203, 1204, 1205, 1211, 1212, 1218, 1219,
+            1225, 1226, 1227, 1230, 1231, 1233
+          ],
+          "summary": {
+            "covered_lines": 28,
+            "num_statements": 43,
+            "percent_covered": 65.11627906976744,
+            "percent_covered_display": "65.12",
+            "missing_lines": 15,
+            "excluded_lines": 0,
+            "percent_statements_covered": 65.11627906976744,
+            "percent_statements_covered_display": "65.12"
+          },
+          "missing_lines": [
+            1146, 1153, 1157, 1158, 1159, 1160, 1167, 1174, 1177, 1180, 1238,
+            1240, 1242, 1243, 1248
+          ],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 6, 8, 9, 26, 27, 28, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+            44, 47, 50, 51, 53, 55, 76, 99, 113, 114, 116, 124, 134, 135, 137,
+            146, 176, 177, 179, 203, 204, 206, 208, 218, 287, 362, 363, 365,
+            367, 378, 518, 519, 521, 522, 524, 541, 567, 577, 613, 614, 616,
+            618, 628, 669, 670, 672, 674, 683, 727, 728, 730, 732, 743, 821,
+            822, 824, 826, 836, 904, 905, 907, 909, 919, 995, 996, 998, 1000,
+            1011, 1103, 1104, 1106, 1108, 1119
+          ],
+          "summary": {
+            "covered_lines": 76,
+            "num_statements": 76,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "BaseCaptchaView": {
+          "executed_lines": [65, 66, 67, 70, 74, 84, 87, 90, 109, 110],
+          "summary": {
+            "covered_lines": 10,
+            "num_statements": 10,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaAPIView": {
+          "executed_lines": [131],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 1,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaRefreshAPIView": {
+          "executed_lines": [159, 160, 162, 164, 165, 166, 170, 173],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 8,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        },
+        "CaptchaAnswerAPIView": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 7,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [190, 191, 194, 196, 197, 198, 200],
+          "excluded_lines": []
+        },
+        "RegisterAPIView": {
+          "executed_lines": [
+            234, 236, 238, 239, 240, 243, 246, 249, 251, 252, 255, 263, 270,
+            273, 298, 299, 300, 303, 309, 310, 311, 318, 319, 322, 323, 324,
+            325, 332, 341, 342, 345, 359
+          ],
+          "summary": {
+            "covered_lines": 32,
+            "num_statements": 38,
+            "percent_covered": 84.21052631578948,
+            "percent_covered_display": "84.21",
+            "missing_lines": 6,
+            "excluded_lines": 0,
+            "percent_statements_covered": 84.21052631578948,
+            "percent_statements_covered_display": "84.21"
+          },
+          "missing_lines": [314, 346, 349, 352, 356, 357],
+          "excluded_lines": []
+        },
+        "LoginAPIView": {
+          "executed_lines": [
+            393, 395, 397, 400, 401, 402, 405, 406, 407, 408, 411, 418, 421,
+            423, 424, 425, 427, 429, 431, 432, 435, 442, 450, 457, 470, 473,
+            476, 477, 482, 483, 484, 485, 488, 489, 495, 501, 504
+          ],
+          "summary": {
+            "covered_lines": 37,
+            "num_statements": 46,
+            "percent_covered": 80.43478260869566,
+            "percent_covered_display": "80.43",
+            "missing_lines": 9,
+            "excluded_lines": 0,
+            "percent_statements_covered": 80.43478260869566,
+            "percent_statements_covered_display": "80.43"
+          },
+          "missing_lines": [412, 413, 414, 415, 466, 467, 496, 497, 498],
+          "excluded_lines": []
+        },
+        "PreviewAPIView": {
+          "executed_lines": [
+            534, 536, 551, 560, 578, 580, 593, 594, 595, 597, 605, 607
+          ],
+          "summary": {
+            "covered_lines": 12,
+            "num_statements": 20,
+            "percent_covered": 60.0,
+            "percent_covered_display": "60.00",
+            "missing_lines": 8,
+            "excluded_lines": 0,
+            "percent_statements_covered": 60.0,
+            "percent_statements_covered_display": "60.00"
+          },
+          "missing_lines": [539, 553, 582, 585, 586, 587, 590, 599],
+          "excluded_lines": []
+        },
+        "TokenRefreshAPIView": {
+          "executed_lines": [638, 640, 641, 646, 648, 649, 652, 657, 658],
+          "summary": {
+            "covered_lines": 9,
+            "num_statements": 11,
+            "percent_covered": 81.81818181818181,
+            "percent_covered_display": "81.82",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 81.81818181818181,
+            "percent_statements_covered_display": "81.82"
+          },
+          "missing_lines": [662, 663],
+          "excluded_lines": []
+        },
+        "LogoutAPIView": {
+          "executed_lines": [694, 700, 702, 704, 714],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 13,
+            "percent_covered": 38.46153846153846,
+            "percent_covered_display": "38.46",
+            "missing_lines": 8,
+            "excluded_lines": 0,
+            "percent_statements_covered": 38.46153846153846,
+            "percent_statements_covered_display": "38.46"
+          },
+          "missing_lines": [695, 705, 707, 708, 709, 711, 719, 721],
+          "excluded_lines": []
+        },
+        "SendEmailVerificationAPIView": {
+          "executed_lines": [758, 759, 760, 766, 769, 776, 779, 782, 793, 799],
+          "summary": {
+            "covered_lines": 10,
+            "num_statements": 17,
+            "percent_covered": 58.8235294117647,
+            "percent_covered_display": "58.82",
+            "missing_lines": 7,
+            "excluded_lines": 0,
+            "percent_statements_covered": 58.8235294117647,
+            "percent_statements_covered_display": "58.82"
+          },
+          "missing_lines": [761, 770, 804, 806, 808, 809, 815],
+          "excluded_lines": []
+        },
+        "VerifyEmailAPIView": {
+          "executed_lines": [
+            846, 848, 849, 850, 851, 857, 858, 864, 865, 874, 875, 876, 877,
+            880, 881, 883
+          ],
+          "summary": {
+            "covered_lines": 16,
+            "num_statements": 21,
+            "percent_covered": 76.19047619047619,
+            "percent_covered_display": "76.19",
+            "missing_lines": 5,
+            "excluded_lines": 0,
+            "percent_statements_covered": 76.19047619047619,
+            "percent_statements_covered_display": "76.19"
+          },
+          "missing_lines": [888, 890, 892, 893, 898],
+          "excluded_lines": []
+        },
+        "ResendEmailVerificationAPIView": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 23,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 23,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [
+            929, 931, 932, 933, 939, 940, 941, 942, 948, 949, 955, 958, 961,
+            962, 963, 964, 967, 973, 978, 980, 982, 983, 989
+          ],
+          "excluded_lines": []
+        },
+        "SendPasswordResetAPIView": {
+          "executed_lines": [
+            1025, 1026, 1027, 1029, 1030, 1031, 1034, 1035, 1042, 1051, 1054,
+            1057, 1059, 1062, 1065, 1075, 1082
+          ],
+          "summary": {
+            "covered_lines": 17,
+            "num_statements": 23,
+            "percent_covered": 73.91304347826087,
+            "percent_covered_display": "73.91",
+            "missing_lines": 6,
+            "excluded_lines": 0,
+            "percent_statements_covered": 73.91304347826087,
+            "percent_statements_covered_display": "73.91"
+          },
+          "missing_lines": [1036, 1087, 1089, 1091, 1092, 1097],
+          "excluded_lines": []
+        },
+        "PasswordResetAPIView": {
+          "executed_lines": [
+            1133, 1134, 1135, 1137, 1140, 1141, 1142, 1144, 1145, 1166, 1173,
+            1189, 1198, 1199, 1202, 1203, 1204, 1205, 1211, 1212, 1218, 1219,
+            1225, 1226, 1227, 1230, 1231, 1233
+          ],
+          "summary": {
+            "covered_lines": 28,
+            "num_statements": 43,
+            "percent_covered": 65.11627906976744,
+            "percent_covered_display": "65.12",
+            "missing_lines": 15,
+            "excluded_lines": 0,
+            "percent_statements_covered": 65.11627906976744,
+            "percent_statements_covered_display": "65.12"
+          },
+          "missing_lines": [
+            1146, 1153, 1157, 1158, 1159, 1160, 1167, 1174, 1177, 1180, 1238,
+            1240, 1242, 1243, 1248
+          ],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [
+            3, 5, 6, 8, 9, 26, 27, 28, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+            44, 47, 50, 51, 53, 55, 76, 99, 113, 114, 116, 124, 134, 135, 137,
+            146, 176, 177, 179, 203, 204, 206, 208, 218, 287, 362, 363, 365,
+            367, 378, 518, 519, 521, 522, 524, 541, 567, 577, 613, 614, 616,
+            618, 628, 669, 670, 672, 674, 683, 727, 728, 730, 732, 743, 821,
+            822, 824, 826, 836, 904, 905, 907, 909, 919, 995, 996, 998, 1000,
+            1011, 1103, 1104, 1106, 1108, 1119
+          ],
+          "summary": {
+            "covered_lines": 76,
+            "num_statements": 76,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "bravo\\__init__.py": {
+    "bravo/__init__.py": {
       "executed_lines": [4, 6],
       "summary": {
         "covered_lines": 2,
@@ -473,12 +3209,48 @@
         "percent_covered": 100.0,
         "percent_covered_display": "100.00",
         "missing_lines": 0,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 100.0,
+        "percent_statements_covered_display": "100.00"
       },
       "missing_lines": [],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "": {
+          "executed_lines": [4, 6],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 2,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [4, 6],
+          "summary": {
+            "covered_lines": 2,
+            "num_statements": 2,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      }
     },
-    "bravo\\celery.py": {
+    "bravo/celery.py": {
       "executed_lines": [1, 3, 6, 8, 11, 14, 17, 18],
       "summary": {
         "covered_lines": 8,
@@ -486,12 +3258,63 @@
         "percent_covered": 88.88888888888889,
         "percent_covered_display": "88.89",
         "missing_lines": 1,
-        "excluded_lines": 0
+        "excluded_lines": 0,
+        "percent_statements_covered": 88.88888888888889,
+        "percent_statements_covered_display": "88.89"
       },
       "missing_lines": [19],
-      "excluded_lines": []
+      "excluded_lines": [],
+      "functions": {
+        "debug_task": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [19],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [1, 3, 6, 8, 11, 14, 17, 18],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 8,
+            "percent_covered": 100.0,
+            "percent_covered_display": "100.00",
+            "missing_lines": 0,
+            "excluded_lines": 0,
+            "percent_statements_covered": 100.0,
+            "percent_statements_covered_display": "100.00"
+          },
+          "missing_lines": [],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [1, 3, 6, 8, 11, 14, 17, 18],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 9,
+            "percent_covered": 88.88888888888889,
+            "percent_covered_display": "88.89",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 88.88888888888889,
+            "percent_statements_covered_display": "88.89"
+          },
+          "missing_lines": [19],
+          "excluded_lines": []
+        }
+      }
     },
-    "bravo\\urls.py": {
+    "bravo/urls.py": {
       "executed_lines": [],
       "summary": {
         "covered_lines": 0,
@@ -499,31 +3322,150 @@
         "percent_covered": 0.0,
         "percent_covered_display": "0.00",
         "missing_lines": 12,
-        "excluded_lines": 3
+        "excluded_lines": 3,
+        "percent_statements_covered": 0.0,
+        "percent_statements_covered_display": "0.00"
       },
-      "missing_lines": [16, 18, 19, 20, 21, 22, 23, 30, 32, 45, 47, 60],
-      "excluded_lines": [81, 82, 83]
+      "missing_lines": [17, 19, 20, 21, 22, 23, 24, 31, 33, 46, 48, 61],
+      "excluded_lines": [88, 89, 90],
+      "functions": {
+        "health_check": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [33],
+          "excluded_lines": []
+        },
+        "api_root": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [48],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 10,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 10,
+            "excluded_lines": 3,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [17, 19, 20, 21, 22, 23, 24, 31, 46, 61],
+          "excluded_lines": [88, 89, 90]
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 12,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 12,
+            "excluded_lines": 3,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [17, 19, 20, 21, 22, 23, 24, 31, 33, 46, 48, 61],
+          "excluded_lines": [88, 89, 90]
+        }
+      }
     },
-    "bravo\\urls_test.py": {
-      "executed_lines": [2, 4, 5, 6, 7, 10, 26],
+    "bravo/urls_test.py": {
+      "executed_lines": [2, 4, 5, 6, 7, 9, 10, 16, 21, 37, 60, 61],
       "summary": {
-        "covered_lines": 7,
-        "num_statements": 8,
-        "percent_covered": 87.5,
-        "percent_covered_display": "87.50",
-        "missing_lines": 1,
-        "excluded_lines": 0
+        "covered_lines": 11,
+        "num_statements": 14,
+        "percent_covered": 78.57142857142857,
+        "percent_covered_display": "78.57",
+        "missing_lines": 3,
+        "excluded_lines": 0,
+        "percent_statements_covered": 78.57142857142857,
+        "percent_statements_covered_display": "78.57"
       },
-      "missing_lines": [12],
-      "excluded_lines": []
+      "missing_lines": [17, 18, 23],
+      "excluded_lines": [],
+      "functions": {
+        "home_view": {
+          "executed_lines": [],
+          "summary": {
+            "covered_lines": 0,
+            "num_statements": 1,
+            "percent_covered": 0.0,
+            "percent_covered_display": "0.00",
+            "missing_lines": 1,
+            "excluded_lines": 0,
+            "percent_statements_covered": 0.0,
+            "percent_statements_covered_display": "0.00"
+          },
+          "missing_lines": [23],
+          "excluded_lines": []
+        },
+        "": {
+          "executed_lines": [2, 4, 5, 6, 7, 9, 10, 16, 21, 37, 60, 61],
+          "summary": {
+            "covered_lines": 11,
+            "num_statements": 13,
+            "percent_covered": 84.61538461538461,
+            "percent_covered_display": "84.62",
+            "missing_lines": 2,
+            "excluded_lines": 0,
+            "percent_statements_covered": 84.61538461538461,
+            "percent_statements_covered_display": "84.62"
+          },
+          "missing_lines": [17, 18],
+          "excluded_lines": []
+        }
+      },
+      "classes": {
+        "": {
+          "executed_lines": [2, 4, 5, 6, 7, 9, 10, 16, 21, 37, 60, 61],
+          "summary": {
+            "covered_lines": 11,
+            "num_statements": 14,
+            "percent_covered": 78.57142857142857,
+            "percent_covered_display": "78.57",
+            "missing_lines": 3,
+            "excluded_lines": 0,
+            "percent_statements_covered": 78.57142857142857,
+            "percent_statements_covered_display": "78.57"
+          },
+          "missing_lines": [17, 18, 23],
+          "excluded_lines": []
+        }
+      }
     }
   },
   "totals": {
-    "covered_lines": 437,
-    "num_statements": 916,
-    "percent_covered": 47.70742358078603,
-    "percent_covered_display": "47.71",
-    "missing_lines": 479,
-    "excluded_lines": 3
+    "covered_lines": 726,
+    "num_statements": 981,
+    "percent_covered": 74.00611620795107,
+    "percent_covered_display": "74.01",
+    "missing_lines": 255,
+    "excluded_lines": 3,
+    "percent_statements_covered": 74.00611620795107,
+    "percent_statements_covered_display": "74.01"
   }
 }

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -404,8 +404,8 @@ describe('Auth Store', () => {
 
       const store = useAuthStore()
       const mockClient = {
-        get: vi.fn().mockResolvedValueOnce(mockResponse),
-        post: vi.fn(),
+        get: vi.fn(),
+        post: vi.fn().mockResolvedValueOnce(mockResponse),
         put: vi.fn(),
         delete: vi.fn(),
         patch: vi.fn(),
@@ -418,6 +418,10 @@ describe('Auth Store', () => {
 
       await store.refreshCaptcha()
 
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/api/auth/captcha/refresh/',
+        {}
+      )
       expect(store.captcha).toEqual({
         id: 'new-captcha-id',
         image: 'data:image/png;base64,newImage...',

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -332,10 +332,12 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  const refreshCaptcha = async (): Promise<Captcha> => {
+  const refreshCaptcha = async (oldCaptchaId?: string): Promise<Captcha> => {
     try {
-      const response = await getApiClient().get<CaptchaResponse>(
-        '/api/auth/captcha/refresh/'
+      // 使用POST方法，与后端API一致
+      const response = await getApiClient().post<CaptchaResponse>(
+        '/api/auth/captcha/refresh/',
+        oldCaptchaId ? { captcha_id: oldCaptchaId } : {}
       )
 
       const captchaData = parseCaptchaResponse(response.data)


### PR DESCRIPTION
## 修复内容

- 前端：将refreshCaptcha从GET改为POST，支持传递旧的captcha_id
- 后端：添加CaptchaRefreshRequestSerializer验证，确保请求数据格式正确
- 测试：更新refreshCaptcha测试以匹配新的POST实现

## 问题

- 前端stores/auth.ts中的refreshCaptcha使用GET方法，但后端只接受POST
- 后端视图缺少序列化器验证，可能导致请求数据格式错误
- dev环境验证码刷新时出现HTTP 400错误

## 修复后

- 统一前后端API调用方式
- 修复dev环境验证码刷新时的HTTP 400错误
- 所有测试通过